### PR TITLE
feat(web):API-сервис команд и хуки (#222)

### DIFF
--- a/apps/web/shared/api/use-team-invitations.ts
+++ b/apps/web/shared/api/use-team-invitations.ts
@@ -1,0 +1,95 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+import {
+	teamInvitationsService,
+	type SendInvitation,
+	type Team,
+	type TeamInvitation,
+} from '@/shared/lib/api/team-invitations-service'
+import type { ApiError } from '@/shared/lib/api/types'
+
+import { teamsKeys } from './use-teams'
+
+export const teamInvitationsKeys = {
+	all: ['teams', 'invitations'] as const,
+	teamLists: () => [...teamInvitationsKeys.all, 'team-list'] as const,
+	teamList: (teamId: string) => [...teamInvitationsKeys.teamLists(), teamId] as const,
+	send: (teamId: string) => [...teamInvitationsKeys.all, 'send', teamId] as const,
+	revoke: (teamId: string) => [...teamInvitationsKeys.all, 'revoke', teamId] as const,
+	myLists: () => [...teamInvitationsKeys.all, 'my-list'] as const,
+	myList: () => [...teamInvitationsKeys.myLists()] as const,
+	accept: () => [...teamInvitationsKeys.all, 'accept'] as const,
+	decline: () => [...teamInvitationsKeys.all, 'decline'] as const,
+} as const
+
+export const useTeamInvitations = (teamId: string) => {
+	return useQuery({
+		queryKey: teamInvitationsKeys.teamList(teamId),
+		queryFn: () => teamInvitationsService.getTeamInvitations(teamId),
+		enabled: Boolean(teamId),
+	})
+}
+
+export const useSendTeamInvitation = (teamId: string) => {
+	const queryClient = useQueryClient()
+
+	return useMutation<TeamInvitation, ApiError, SendInvitation>({
+		mutationKey: teamInvitationsKeys.send(teamId || 'mutation'),
+		mutationFn: (data) => teamInvitationsService.sendInvitation(teamId, data),
+		onSuccess: () =>
+			queryClient.invalidateQueries({
+				queryKey: teamInvitationsKeys.teamList(teamId),
+			}),
+	})
+}
+
+export const useRevokeTeamInvitation = (teamId: string) => {
+	const queryClient = useQueryClient()
+
+	return useMutation<TeamInvitation, ApiError, string>({
+		mutationKey: teamInvitationsKeys.revoke(teamId || 'mutation'),
+		mutationFn: (invitationId) =>
+			teamInvitationsService.revokeInvitation(teamId, invitationId),
+		onSuccess: () =>
+			queryClient.invalidateQueries({
+				queryKey: teamInvitationsKeys.teamList(teamId),
+			}),
+	})
+}
+
+export const useMyInvitations = () => {
+	return useQuery({
+		queryKey: teamInvitationsKeys.myList(),
+		queryFn: teamInvitationsService.getMyInvitations,
+	})
+}
+
+export const useAcceptInvitation = () => {
+	const queryClient = useQueryClient()
+
+	return useMutation<Team, ApiError, string>({
+		mutationKey: teamInvitationsKeys.accept(),
+		mutationFn: teamInvitationsService.acceptInvitation,
+		onSuccess: async (team) => {
+			queryClient.setQueryData(teamsKeys.detail(team.id), team)
+
+			await Promise.all([
+				queryClient.invalidateQueries({ queryKey: teamsKeys.lists() }),
+				queryClient.invalidateQueries({ queryKey: teamInvitationsKeys.myList() }),
+			])
+		},
+	})
+}
+
+export const useDeclineInvitation = () => {
+	const queryClient = useQueryClient()
+
+	return useMutation<TeamInvitation, ApiError, string>({
+		mutationKey: teamInvitationsKeys.decline(),
+		mutationFn: teamInvitationsService.declineInvitation,
+		onSuccess: () =>
+			queryClient.invalidateQueries({
+				queryKey: teamInvitationsKeys.myList(),
+			}),
+	})
+}

--- a/apps/web/shared/api/use-team-members.ts
+++ b/apps/web/shared/api/use-team-members.ts
@@ -1,0 +1,60 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+import {
+	teamMembersService,
+	type ChangeRole,
+	type DeleteTeamResponse,
+	type TeamMember,
+} from '@/shared/lib/api/team-members-service'
+import type { ApiError } from '@/shared/lib/api/types'
+
+import { teamsKeys } from './use-teams'
+
+export const teamMembersKeys = {
+	all: ['teams', 'members'] as const,
+	lists: () => [...teamMembersKeys.all, 'list'] as const,
+	list: (teamId: string) => [...teamMembersKeys.lists(), teamId] as const,
+	changeRole: (teamId: string) =>
+		[...teamMembersKeys.all, 'change-role', teamId] as const,
+	remove: (teamId: string) => [...teamMembersKeys.all, 'remove', teamId] as const,
+} as const
+
+export const useTeamMembers = (teamId: string) => {
+	return useQuery({
+		queryKey: teamMembersKeys.list(teamId),
+		queryFn: () => teamMembersService.getMembers(teamId),
+		enabled: Boolean(teamId),
+	})
+}
+
+export const useChangeMemberRole = (teamId: string) => {
+	const queryClient = useQueryClient()
+
+	return useMutation<TeamMember, ApiError, { userId: string; data: ChangeRole }>({
+		mutationKey: teamMembersKeys.changeRole(teamId || 'mutation'),
+		mutationFn: ({ userId, data }) => teamMembersService.changeRole(teamId, userId, data),
+		onSuccess: async () => {
+			await Promise.all([
+				queryClient.invalidateQueries({ queryKey: teamMembersKeys.list(teamId) }),
+				queryClient.invalidateQueries({ queryKey: teamsKeys.detail(teamId) }),
+				queryClient.invalidateQueries({ queryKey: teamsKeys.lists() }),
+			])
+		},
+	})
+}
+
+export const useRemoveTeamMember = (teamId: string) => {
+	const queryClient = useQueryClient()
+
+	return useMutation<DeleteTeamResponse, ApiError, string>({
+		mutationKey: teamMembersKeys.remove(teamId || 'mutation'),
+		mutationFn: (userId) => teamMembersService.removeMember(teamId, userId),
+		onSuccess: async () => {
+			await Promise.all([
+				queryClient.invalidateQueries({ queryKey: teamMembersKeys.list(teamId) }),
+				queryClient.invalidateQueries({ queryKey: teamsKeys.detail(teamId) }),
+				queryClient.invalidateQueries({ queryKey: teamsKeys.lists() }),
+			])
+		},
+	})
+}

--- a/apps/web/shared/lib/api/team-invitations-service.ts
+++ b/apps/web/shared/lib/api/team-invitations-service.ts
@@ -14,6 +14,9 @@ export type { MyInvitation, SendInvitation, Team, TeamInvitation }
 
 const TEAMS_ENDPOINT = '/teams'
 const INVITATIONS_ENDPOINT = '/invitations'
+const buildTeamInvitationsEndpoint = (teamId: string) =>
+	`${TEAMS_ENDPOINT}/${teamId}/invitations`
+const buildInvitationEndpoint = (token: string) => `${INVITATIONS_ENDPOINT}/${token}`
 
 export const teamInvitationsService = {
 	sendInvitation: async (
@@ -21,7 +24,7 @@ export const teamInvitationsService = {
 		body: SendInvitation,
 	): Promise<TeamInvitation> => {
 		const response = await client.post<TeamInvitationApiResponse>(
-			`${TEAMS_ENDPOINT}/${teamId}/invitations`,
+			buildTeamInvitationsEndpoint(teamId),
 			body,
 		)
 
@@ -30,7 +33,7 @@ export const teamInvitationsService = {
 
 	getTeamInvitations: async (teamId: string): Promise<TeamInvitation[]> => {
 		const response = await client.get<TeamInvitationApiResponse[]>(
-			`${TEAMS_ENDPOINT}/${teamId}/invitations`,
+			buildTeamInvitationsEndpoint(teamId),
 		)
 
 		return response.data.map(normalizeTeamInvitation)
@@ -41,7 +44,7 @@ export const teamInvitationsService = {
 		invitationId: string,
 	): Promise<TeamInvitation> => {
 		const response = await client.delete<TeamInvitationApiResponse>(
-			`${TEAMS_ENDPOINT}/${teamId}/invitations/${invitationId}`,
+			`${buildTeamInvitationsEndpoint(teamId)}/${invitationId}`,
 		)
 
 		return normalizeTeamInvitation(response.data)
@@ -57,7 +60,7 @@ export const teamInvitationsService = {
 
 	acceptInvitation: async (token: string): Promise<Team> => {
 		const response = await client.post<TeamApiResponse>(
-			`${INVITATIONS_ENDPOINT}/${token}/accept`,
+			`${buildInvitationEndpoint(token)}/accept`,
 		)
 
 		return normalizeTeam(response.data)
@@ -65,7 +68,7 @@ export const teamInvitationsService = {
 
 	declineInvitation: async (token: string): Promise<TeamInvitation> => {
 		const response = await client.post<TeamInvitationApiResponse>(
-			`${INVITATIONS_ENDPOINT}/${token}/decline`,
+			`${buildInvitationEndpoint(token)}/decline`,
 		)
 
 		return normalizeTeamInvitation(response.data)

--- a/apps/web/shared/lib/api/team-invitations-service.ts
+++ b/apps/web/shared/lib/api/team-invitations-service.ts
@@ -1,0 +1,73 @@
+import type { MyInvitation, SendInvitation, Team, TeamInvitation } from '@repo/types'
+
+import { client } from './client'
+import {
+	normalizeMyInvitation,
+	normalizeTeam,
+	normalizeTeamInvitation,
+	type MyInvitationApiResponse,
+	type TeamApiResponse,
+	type TeamInvitationApiResponse,
+} from './teams-normalizers'
+
+export type { MyInvitation, SendInvitation, Team, TeamInvitation }
+
+const TEAMS_ENDPOINT = '/teams'
+const INVITATIONS_ENDPOINT = '/invitations'
+
+export const teamInvitationsService = {
+	sendInvitation: async (
+		teamId: string,
+		body: SendInvitation,
+	): Promise<TeamInvitation> => {
+		const response = await client.post<TeamInvitationApiResponse>(
+			`${TEAMS_ENDPOINT}/${teamId}/invitations`,
+			body,
+		)
+
+		return normalizeTeamInvitation(response.data)
+	},
+
+	getTeamInvitations: async (teamId: string): Promise<TeamInvitation[]> => {
+		const response = await client.get<TeamInvitationApiResponse[]>(
+			`${TEAMS_ENDPOINT}/${teamId}/invitations`,
+		)
+
+		return response.data.map(normalizeTeamInvitation)
+	},
+
+	revokeInvitation: async (
+		teamId: string,
+		invitationId: string,
+	): Promise<TeamInvitation> => {
+		const response = await client.delete<TeamInvitationApiResponse>(
+			`${TEAMS_ENDPOINT}/${teamId}/invitations/${invitationId}`,
+		)
+
+		return normalizeTeamInvitation(response.data)
+	},
+
+	getMyInvitations: async (): Promise<MyInvitation[]> => {
+		const response = await client.get<MyInvitationApiResponse[]>(
+			`${INVITATIONS_ENDPOINT}/me`,
+		)
+
+		return response.data.map(normalizeMyInvitation)
+	},
+
+	acceptInvitation: async (token: string): Promise<Team> => {
+		const response = await client.post<TeamApiResponse>(
+			`${INVITATIONS_ENDPOINT}/${token}/accept`,
+		)
+
+		return normalizeTeam(response.data)
+	},
+
+	declineInvitation: async (token: string): Promise<TeamInvitation> => {
+		const response = await client.post<TeamInvitationApiResponse>(
+			`${INVITATIONS_ENDPOINT}/${token}/decline`,
+		)
+
+		return normalizeTeamInvitation(response.data)
+	},
+}

--- a/apps/web/shared/lib/api/team-members-service.ts
+++ b/apps/web/shared/lib/api/team-members-service.ts
@@ -1,0 +1,43 @@
+import type { ChangeRole, DeleteTeamResponse, TeamMember } from '@repo/types'
+
+import { client } from './client'
+import { normalizeTeamMember, type TeamApiMember } from './teams-normalizers'
+
+export type { ChangeRole, DeleteTeamResponse, TeamMember }
+
+const ENDPOINT = '/teams'
+
+type TeamMemberApiResponse = TeamApiMember & {
+	teamId?: string
+}
+
+export const teamMembersService = {
+	getMembers: async (teamId: string): Promise<TeamMember[]> => {
+		const response = await client.get<TeamMemberApiResponse[]>(
+			`${ENDPOINT}/${teamId}/members`,
+		)
+
+		return response.data.map(normalizeTeamMember)
+	},
+
+	changeRole: async (
+		teamId: string,
+		userId: string,
+		body: ChangeRole,
+	): Promise<TeamMember> => {
+		const response = await client.patch<TeamMemberApiResponse>(
+			`${ENDPOINT}/${teamId}/members/${userId}/role`,
+			body,
+		)
+
+		return normalizeTeamMember(response.data)
+	},
+
+	removeMember: async (teamId: string, userId: string): Promise<DeleteTeamResponse> => {
+		const response = await client.delete<DeleteTeamResponse>(
+			`${ENDPOINT}/${teamId}/members/${userId}`,
+		)
+
+		return response.data
+	},
+}

--- a/apps/web/shared/lib/api/team-members-service.ts
+++ b/apps/web/shared/lib/api/team-members-service.ts
@@ -1,20 +1,17 @@
 import type { ChangeRole, DeleteTeamResponse, TeamMember } from '@repo/types'
 
 import { client } from './client'
-import { normalizeTeamMember, type TeamApiMember } from './teams-normalizers'
+import { normalizeTeamMember, type TeamMemberApiResponse } from './teams-normalizers'
 
 export type { ChangeRole, DeleteTeamResponse, TeamMember }
 
-const ENDPOINT = '/teams'
-
-type TeamMemberApiResponse = TeamApiMember & {
-	teamId?: string
-}
+const TEAMS_ENDPOINT = '/teams'
+const buildTeamMembersEndpoint = (teamId: string) => `${TEAMS_ENDPOINT}/${teamId}/members`
 
 export const teamMembersService = {
 	getMembers: async (teamId: string): Promise<TeamMember[]> => {
 		const response = await client.get<TeamMemberApiResponse[]>(
-			`${ENDPOINT}/${teamId}/members`,
+			buildTeamMembersEndpoint(teamId),
 		)
 
 		return response.data.map(normalizeTeamMember)
@@ -26,7 +23,7 @@ export const teamMembersService = {
 		body: ChangeRole,
 	): Promise<TeamMember> => {
 		const response = await client.patch<TeamMemberApiResponse>(
-			`${ENDPOINT}/${teamId}/members/${userId}/role`,
+			`${buildTeamMembersEndpoint(teamId)}/${userId}/role`,
 			body,
 		)
 
@@ -35,7 +32,7 @@ export const teamMembersService = {
 
 	removeMember: async (teamId: string, userId: string): Promise<DeleteTeamResponse> => {
 		const response = await client.delete<DeleteTeamResponse>(
-			`${ENDPOINT}/${teamId}/members/${userId}`,
+			`${buildTeamMembersEndpoint(teamId)}/${userId}`,
 		)
 
 		return response.data

--- a/apps/web/shared/lib/api/teams-normalizers.ts
+++ b/apps/web/shared/lib/api/teams-normalizers.ts
@@ -7,41 +7,81 @@ import type {
 	TeamMember,
 } from '@repo/types'
 
-export type TeamApiMember = Partial<TeamMember> & {
-	user?: {
-		id?: string
-		name?: string | null
-		email?: string
-	} | null
+type TeamMemberUserApiResponse = {
+	id: string
+	name: string | null
+	email: string
 }
+
+type NestedTeamMemberApiResponse = {
+	id?: string
+	userId?: string
+	role: TeamMember['role']
+	joinedAt?: string
+	user: TeamMemberUserApiResponse
+}
+
+export type TeamMemberApiResponse = TeamMember | NestedTeamMemberApiResponse
 
 export type TeamApiResponse = Omit<Team, 'members'> & {
-	members: TeamApiMember[]
+	members: TeamMemberApiResponse[]
 }
 
-export type TeamInvitationApiResponse = Omit<
-	Partial<TeamInvitation>,
-	'team' | 'invitedBy'
-> & {
-	team?: Partial<InvitationTeamSummary> | null
-	invitedBy?: Partial<InvitationInvitedBy> | null
+type InvitationInvitedByApiResponse = {
+	id?: string
+	name?: string | null
+	email?: string
+} | null
+
+type InvitationTeamSummaryApiResponse = {
+	id?: string
+	name?: string
+	avatarUrl?: string | null
+} | null
+
+export type TeamInvitationApiResponse = {
+	id?: string
+	teamId?: string
+	invitedById?: string
+	email?: string
+	role?: TeamInvitation['role']
+	status?: TeamInvitation['status']
+	token?: string
+	expiresAt?: string
+	createdAt?: string
+	updatedAt?: string
+	team?: InvitationTeamSummaryApiResponse
+	invitedBy?: InvitationInvitedByApiResponse
 }
 
-export type MyInvitationApiResponse = Omit<
-	Partial<MyInvitation>,
-	'team' | 'invitedBy'
-> & {
-	team?: Partial<InvitationTeamSummary> | null
-	invitedBy?: Partial<InvitationInvitedBy> | null
+export type MyInvitationApiResponse = {
+	id?: string
+	email?: string
+	role?: MyInvitation['role']
+	token?: string
+	expiresAt?: string
+	createdAt?: string
+	team?: InvitationTeamSummaryApiResponse
+	invitedBy?: InvitationInvitedByApiResponse
 }
 
-export function normalizeTeamMember(member: TeamApiMember): TeamMember {
+function hasNestedUser(
+	member: TeamMemberApiResponse,
+): member is NestedTeamMemberApiResponse {
+	return 'user' in member && member.user !== null && member.user !== undefined
+}
+
+export function normalizeTeamMember(member: TeamMemberApiResponse): TeamMember {
+	if (!hasNestedUser(member)) {
+		return member
+	}
+
 	return {
-		id: member.id ?? member.userId ?? member.user?.id ?? '',
-		userId: member.userId ?? member.user?.id ?? '',
-		name: member.name ?? member.user?.name ?? null,
-		email: member.email ?? member.user?.email ?? '',
-		role: member.role ?? 'MEMBER',
+		id: member.id ?? member.userId ?? member.user.id,
+		userId: member.userId ?? member.user.id,
+		name: member.user.name,
+		email: member.user.email,
+		role: member.role,
 		joinedAt: member.joinedAt ?? '',
 	}
 }
@@ -49,27 +89,31 @@ export function normalizeTeamMember(member: TeamApiMember): TeamMember {
 export function normalizeTeam(team: TeamApiResponse): Team {
 	return {
 		...team,
-		members: Array.isArray(team.members) ? team.members.map(normalizeTeamMember) : [],
+		members: team.members.map(normalizeTeamMember),
 	}
 }
 
-export function normalizeInvitationInvitedBy(
-	invitedBy?: Partial<InvitationInvitedBy> | null,
+function normalizeInvitationInvitedBy(
+	invitedBy?: InvitationInvitedByApiResponse,
 ): InvitationInvitedBy {
+	const source = invitedBy ?? {}
+
 	return {
-		id: invitedBy?.id ?? '',
-		name: invitedBy?.name ?? null,
-		email: invitedBy?.email ?? '',
+		id: source.id ?? '',
+		name: source.name ?? null,
+		email: source.email ?? '',
 	}
 }
 
-export function normalizeInvitationTeamSummary(
-	team?: Partial<InvitationTeamSummary> | null,
+function normalizeInvitationTeamSummary(
+	team?: InvitationTeamSummaryApiResponse,
 ): InvitationTeamSummary {
+	const source = team ?? {}
+
 	return {
-		id: team?.id ?? '',
-		name: team?.name ?? '',
-		avatarUrl: team?.avatarUrl ?? null,
+		id: source.id ?? '',
+		name: source.name ?? '',
+		avatarUrl: source.avatarUrl ?? null,
 	}
 }
 

--- a/apps/web/shared/lib/api/teams-normalizers.ts
+++ b/apps/web/shared/lib/api/teams-normalizers.ts
@@ -1,0 +1,106 @@
+import type {
+	InvitationInvitedBy,
+	InvitationTeamSummary,
+	MyInvitation,
+	Team,
+	TeamInvitation,
+	TeamMember,
+} from '@repo/types'
+
+export type TeamApiMember = Partial<TeamMember> & {
+	user?: {
+		id?: string
+		name?: string | null
+		email?: string
+	} | null
+}
+
+export type TeamApiResponse = Omit<Team, 'members'> & {
+	members: TeamApiMember[]
+}
+
+export type TeamInvitationApiResponse = Omit<
+	Partial<TeamInvitation>,
+	'team' | 'invitedBy'
+> & {
+	team?: Partial<InvitationTeamSummary> | null
+	invitedBy?: Partial<InvitationInvitedBy> | null
+}
+
+export type MyInvitationApiResponse = Omit<
+	Partial<MyInvitation>,
+	'team' | 'invitedBy'
+> & {
+	team?: Partial<InvitationTeamSummary> | null
+	invitedBy?: Partial<InvitationInvitedBy> | null
+}
+
+export function normalizeTeamMember(member: TeamApiMember): TeamMember {
+	return {
+		id: member.id ?? member.userId ?? member.user?.id ?? '',
+		userId: member.userId ?? member.user?.id ?? '',
+		name: member.name ?? member.user?.name ?? null,
+		email: member.email ?? member.user?.email ?? '',
+		role: member.role ?? 'MEMBER',
+		joinedAt: member.joinedAt ?? '',
+	}
+}
+
+export function normalizeTeam(team: TeamApiResponse): Team {
+	return {
+		...team,
+		members: Array.isArray(team.members) ? team.members.map(normalizeTeamMember) : [],
+	}
+}
+
+export function normalizeInvitationInvitedBy(
+	invitedBy?: Partial<InvitationInvitedBy> | null,
+): InvitationInvitedBy {
+	return {
+		id: invitedBy?.id ?? '',
+		name: invitedBy?.name ?? null,
+		email: invitedBy?.email ?? '',
+	}
+}
+
+export function normalizeInvitationTeamSummary(
+	team?: Partial<InvitationTeamSummary> | null,
+): InvitationTeamSummary {
+	return {
+		id: team?.id ?? '',
+		name: team?.name ?? '',
+		avatarUrl: team?.avatarUrl ?? null,
+	}
+}
+
+export function normalizeTeamInvitation(
+	invitation: TeamInvitationApiResponse,
+): TeamInvitation {
+	return {
+		id: invitation.id ?? '',
+		teamId: invitation.teamId ?? '',
+		invitedById: invitation.invitedById ?? '',
+		email: invitation.email ?? '',
+		role: invitation.role ?? 'MEMBER',
+		status: invitation.status ?? 'PENDING',
+		token: invitation.token ?? '',
+		expiresAt: invitation.expiresAt ?? '',
+		createdAt: invitation.createdAt ?? '',
+		updatedAt: invitation.updatedAt ?? '',
+		invitedBy: normalizeInvitationInvitedBy(invitation.invitedBy),
+		team: normalizeInvitationTeamSummary(invitation.team),
+	}
+}
+
+export function normalizeMyInvitation(invitation: MyInvitationApiResponse): MyInvitation {
+	return {
+		id: invitation.id ?? '',
+		email: invitation.email ?? '',
+		role: invitation.role ?? 'MEMBER',
+		token: invitation.token ?? '',
+		expiresAt: invitation.expiresAt ?? '',
+		createdAt: invitation.createdAt ?? '',
+		team: normalizeInvitationTeamSummary(invitation.team),
+		invitedBy: normalizeInvitationInvitedBy(invitation.invitedBy),
+	}
+}

--- a/apps/web/shared/lib/api/teams-service.ts
+++ b/apps/web/shared/lib/api/teams-service.ts
@@ -3,46 +3,16 @@ import type {
 	DeleteTeamResponse,
 	Team,
 	TeamListItem,
-	TeamMember,
 	UpdateTeam,
 } from '@repo/types'
 
 import { client } from './client'
+import { normalizeTeam, type TeamApiResponse } from './teams-normalizers'
 
 export type { CreateTeam, DeleteTeamResponse, Team, TeamListItem, UpdateTeam }
 
 const ENDPOINT = '/teams'
 const CREATE_ENDPOINT = `${ENDPOINT}/new`
-
-type TeamApiMember = Partial<TeamMember> & {
-	user?: {
-		id?: string
-		name?: string | null
-		email?: string
-	} | null
-}
-
-type TeamApiResponse = Omit<Team, 'members'> & {
-	members: TeamApiMember[]
-}
-
-function normalizeTeamMember(member: TeamApiMember): TeamMember {
-	return {
-		id: member.id ?? member.userId ?? member.user?.id ?? '',
-		userId: member.userId ?? member.user?.id ?? '',
-		name: member.name ?? member.user?.name ?? null,
-		email: member.email ?? member.user?.email ?? '',
-		role: member.role ?? 'MEMBER',
-		joinedAt: member.joinedAt ?? '',
-	}
-}
-
-function normalizeTeam(team: TeamApiResponse): Team {
-	return {
-		...team,
-		members: Array.isArray(team.members) ? team.members.map(normalizeTeamMember) : [],
-	}
-}
 
 export const teamsService = {
 	getAll: async (): Promise<TeamListItem[]> => {

--- a/apps/web/shared/lib/api/teams-service.ts
+++ b/apps/web/shared/lib/api/teams-service.ts
@@ -11,36 +11,37 @@ import { normalizeTeam, type TeamApiResponse } from './teams-normalizers'
 
 export type { CreateTeam, DeleteTeamResponse, Team, TeamListItem, UpdateTeam }
 
-const ENDPOINT = '/teams'
-const CREATE_ENDPOINT = `${ENDPOINT}/new`
+const TEAMS_ENDPOINT = '/teams'
+const TEAM_CREATE_ENDPOINT = `${TEAMS_ENDPOINT}/new`
+const buildTeamEndpoint = (teamId: string) => `${TEAMS_ENDPOINT}/${teamId}`
 
 export const teamsService = {
 	getAll: async (): Promise<TeamListItem[]> => {
-		const response = await client.get<TeamListItem[]>(ENDPOINT)
+		const response = await client.get<TeamListItem[]>(TEAMS_ENDPOINT)
 
 		return response.data
 	},
 
-	getById: async (id: string): Promise<Team> => {
-		const response = await client.get<TeamApiResponse>(`${ENDPOINT}/${id}`)
+	getById: async (teamId: string): Promise<Team> => {
+		const response = await client.get<TeamApiResponse>(buildTeamEndpoint(teamId))
 
 		return normalizeTeam(response.data)
 	},
 
 	create: async (body: CreateTeam): Promise<Team> => {
-		const response = await client.post<TeamApiResponse>(CREATE_ENDPOINT, body)
+		const response = await client.post<TeamApiResponse>(TEAM_CREATE_ENDPOINT, body)
 
 		return normalizeTeam(response.data)
 	},
 
-	update: async (id: string, body: UpdateTeam): Promise<Team> => {
-		const response = await client.patch<TeamApiResponse>(`${ENDPOINT}/${id}`, body)
+	update: async (teamId: string, body: UpdateTeam): Promise<Team> => {
+		const response = await client.patch<TeamApiResponse>(buildTeamEndpoint(teamId), body)
 
 		return normalizeTeam(response.data)
 	},
 
-	delete: async (id: string): Promise<DeleteTeamResponse> => {
-		const response = await client.delete<DeleteTeamResponse>(`${ENDPOINT}/${id}`)
+	delete: async (teamId: string): Promise<DeleteTeamResponse> => {
+		const response = await client.delete<DeleteTeamResponse>(buildTeamEndpoint(teamId))
 
 		return response.data
 	},

--- a/apps/web/test/mocks/api/http-client.mock.ts
+++ b/apps/web/test/mocks/api/http-client.mock.ts
@@ -1,0 +1,27 @@
+import { vi, type MockedFunction } from 'vitest'
+
+type ApiClient = typeof import('@/shared/lib/api/client').client
+
+type MockedApiClient = {
+	get: MockedFunction<ApiClient['get']>
+	post: MockedFunction<ApiClient['post']>
+	patch: MockedFunction<ApiClient['patch']>
+	delete: MockedFunction<ApiClient['delete']>
+}
+
+export const mockApiClient: MockedApiClient = {
+	get: vi.fn<ApiClient['get']>(),
+	post: vi.fn<ApiClient['post']>(),
+	patch: vi.fn<ApiClient['patch']>(),
+	delete: vi.fn<ApiClient['delete']>(),
+}
+
+export function resetApiClientMock() {
+	for (const mockFn of Object.values(mockApiClient)) {
+		mockFn.mockReset()
+	}
+}
+
+vi.mock('@/shared/lib/api/client', () => ({
+	client: mockApiClient,
+}))

--- a/apps/web/test/mocks/api/team-api.fixtures.ts
+++ b/apps/web/test/mocks/api/team-api.fixtures.ts
@@ -1,0 +1,141 @@
+import { AxiosHeaders, type AxiosResponse } from 'axios'
+
+import {
+	TEAM_INVITATION_STATUSES,
+	TEAM_ROLES,
+	type DeleteTeamResponse,
+	type MyInvitation,
+	type TeamInvitation,
+} from '@repo/types'
+
+import type {
+	MyInvitationApiResponse,
+	TeamApiResponse,
+	TeamInvitationApiResponse,
+	TeamMemberApiResponse,
+} from '@/shared/lib/api/teams-normalizers'
+
+import {
+	createTeamFixture,
+	createTeamListItemFixture,
+	createTeamMemberFixture,
+} from '../teams.fixtures'
+
+export { createTeamFixture, createTeamListItemFixture, createTeamMemberFixture }
+
+export function axiosResponse<T>(data: T): AxiosResponse<T> {
+	return {
+		data,
+		status: 200,
+		statusText: 'OK',
+		headers: {},
+		config: { headers: new AxiosHeaders() },
+	}
+}
+
+export function createNestedTeamMemberApiFixture(
+	overrides?: Partial<Extract<TeamMemberApiResponse, { user: unknown }>>,
+): TeamMemberApiResponse {
+	return {
+		id: 'member-1',
+		userId: 'user-1',
+		role: TEAM_ROLES.ADMIN,
+		joinedAt: '2024-02-01',
+		user: {
+			id: 'user-1',
+			name: 'Alex',
+			email: 'alex@test.com',
+		},
+		...overrides,
+	}
+}
+
+export function createTeamApiFixture(
+	overrides?: Partial<TeamApiResponse>,
+): TeamApiResponse {
+	return {
+		...createTeamFixture(),
+		members: [],
+		...overrides,
+	}
+}
+
+export function createTeamInvitationFixture(
+	overrides?: Partial<TeamInvitation>,
+): TeamInvitation {
+	return {
+		id: 'inv-1',
+		teamId: 'team-1',
+		invitedById: 'user-1',
+		email: 'new@test.com',
+		role: TEAM_ROLES.MEMBER,
+		status: TEAM_INVITATION_STATUSES.PENDING,
+		token: 'token-1',
+		expiresAt: '2026-04-11T12:00:00.000Z',
+		createdAt: '2026-04-09T12:00:00.000Z',
+		updatedAt: '2026-04-09T12:00:00.000Z',
+		team: {
+			id: 'team-1',
+			name: 'Dream Team',
+			avatarUrl: null,
+		},
+		invitedBy: {
+			id: 'user-1',
+			name: 'Alex',
+			email: 'alex@test.com',
+		},
+		...overrides,
+	}
+}
+
+export function createTeamInvitationApiFixture(
+	overrides?: Partial<TeamInvitationApiResponse>,
+): TeamInvitationApiResponse {
+	return {
+		...createTeamInvitationFixture(),
+		...overrides,
+	}
+}
+
+export function createMyInvitationFixture(
+	overrides?: Partial<MyInvitation>,
+): MyInvitation {
+	return {
+		id: 'inv-1',
+		email: 'new@test.com',
+		role: TEAM_ROLES.MEMBER,
+		token: 'token-1',
+		expiresAt: '2026-04-11T12:00:00.000Z',
+		createdAt: '2026-04-09T12:00:00.000Z',
+		team: {
+			id: 'team-1',
+			name: 'Dream Team',
+			avatarUrl: null,
+		},
+		invitedBy: {
+			id: 'user-1',
+			name: 'Alex',
+			email: 'alex@test.com',
+		},
+		...overrides,
+	}
+}
+
+export function createMyInvitationApiFixture(
+	overrides?: Partial<MyInvitationApiResponse>,
+): MyInvitationApiResponse {
+	return {
+		...createMyInvitationFixture(),
+		...overrides,
+	}
+}
+
+export function createDeleteTeamResponseFixture(
+	overrides?: Partial<DeleteTeamResponse>,
+): DeleteTeamResponse {
+	return {
+		message: 'Команда успешно удалена',
+		success: true,
+		...overrides,
+	}
+}

--- a/apps/web/test/mocks/api/team-invitations-service.mock.ts
+++ b/apps/web/test/mocks/api/team-invitations-service.mock.ts
@@ -1,0 +1,32 @@
+import { vi, type MockedFunction } from 'vitest'
+
+type TeamInvitationsService =
+	typeof import('@/shared/lib/api/team-invitations-service').teamInvitationsService
+
+type MockedTeamInvitationsService = {
+	sendInvitation: MockedFunction<TeamInvitationsService['sendInvitation']>
+	getTeamInvitations: MockedFunction<TeamInvitationsService['getTeamInvitations']>
+	revokeInvitation: MockedFunction<TeamInvitationsService['revokeInvitation']>
+	getMyInvitations: MockedFunction<TeamInvitationsService['getMyInvitations']>
+	acceptInvitation: MockedFunction<TeamInvitationsService['acceptInvitation']>
+	declineInvitation: MockedFunction<TeamInvitationsService['declineInvitation']>
+}
+
+export const teamInvitationsServiceMock: MockedTeamInvitationsService = {
+	sendInvitation: vi.fn<TeamInvitationsService['sendInvitation']>(),
+	getTeamInvitations: vi.fn<TeamInvitationsService['getTeamInvitations']>(),
+	revokeInvitation: vi.fn<TeamInvitationsService['revokeInvitation']>(),
+	getMyInvitations: vi.fn<TeamInvitationsService['getMyInvitations']>(),
+	acceptInvitation: vi.fn<TeamInvitationsService['acceptInvitation']>(),
+	declineInvitation: vi.fn<TeamInvitationsService['declineInvitation']>(),
+}
+
+export function resetTeamInvitationsServiceMock() {
+	for (const mockFn of Object.values(teamInvitationsServiceMock)) {
+		mockFn.mockReset()
+	}
+}
+
+vi.mock('@/shared/lib/api/team-invitations-service', () => ({
+	teamInvitationsService: teamInvitationsServiceMock,
+}))

--- a/apps/web/test/mocks/api/team-members-service.mock.ts
+++ b/apps/web/test/mocks/api/team-members-service.mock.ts
@@ -1,0 +1,26 @@
+import { vi, type MockedFunction } from 'vitest'
+
+type TeamMembersService =
+	typeof import('@/shared/lib/api/team-members-service').teamMembersService
+
+type MockedTeamMembersService = {
+	getMembers: MockedFunction<TeamMembersService['getMembers']>
+	changeRole: MockedFunction<TeamMembersService['changeRole']>
+	removeMember: MockedFunction<TeamMembersService['removeMember']>
+}
+
+export const teamMembersServiceMock: MockedTeamMembersService = {
+	getMembers: vi.fn<TeamMembersService['getMembers']>(),
+	changeRole: vi.fn<TeamMembersService['changeRole']>(),
+	removeMember: vi.fn<TeamMembersService['removeMember']>(),
+}
+
+export function resetTeamMembersServiceMock() {
+	for (const mockFn of Object.values(teamMembersServiceMock)) {
+		mockFn.mockReset()
+	}
+}
+
+vi.mock('@/shared/lib/api/team-members-service', () => ({
+	teamMembersService: teamMembersServiceMock,
+}))

--- a/apps/web/test/mocks/api/teams-service.mock.ts
+++ b/apps/web/test/mocks/api/teams-service.mock.ts
@@ -1,0 +1,29 @@
+import { vi, type MockedFunction } from 'vitest'
+
+type TeamsService = typeof import('@/shared/lib/api/teams-service').teamsService
+
+type MockedTeamsService = {
+	getAll: MockedFunction<TeamsService['getAll']>
+	getById: MockedFunction<TeamsService['getById']>
+	create: MockedFunction<TeamsService['create']>
+	update: MockedFunction<TeamsService['update']>
+	delete: MockedFunction<TeamsService['delete']>
+}
+
+export const teamsServiceMock: MockedTeamsService = {
+	getAll: vi.fn<TeamsService['getAll']>(),
+	getById: vi.fn<TeamsService['getById']>(),
+	create: vi.fn<TeamsService['create']>(),
+	update: vi.fn<TeamsService['update']>(),
+	delete: vi.fn<TeamsService['delete']>(),
+}
+
+export function resetTeamsServiceMock() {
+	for (const mockFn of Object.values(teamsServiceMock)) {
+		mockFn.mockReset()
+	}
+}
+
+vi.mock('@/shared/lib/api/teams-service', () => ({
+	teamsService: teamsServiceMock,
+}))

--- a/apps/web/test/unit/shared/api/team-invitations-keys.spec.ts
+++ b/apps/web/test/unit/shared/api/team-invitations-keys.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { teamInvitationsKeys } from '@/shared/api/use-team-invitations'
+
+describe('teamInvitationsKeys', () => {
+	it('all', () => {
+		expect(teamInvitationsKeys.all).toEqual(['teams', 'invitations'])
+	})
+
+	it('teamLists', () => {
+		expect(teamInvitationsKeys.teamLists()).toEqual(['teams', 'invitations', 'team-list'])
+	})
+
+	it('teamList', () => {
+		expect(teamInvitationsKeys.teamList('team-1')).toEqual([
+			'teams',
+			'invitations',
+			'team-list',
+			'team-1',
+		])
+	})
+
+	it('send', () => {
+		expect(teamInvitationsKeys.send('team-1')).toEqual([
+			'teams',
+			'invitations',
+			'send',
+			'team-1',
+		])
+	})
+
+	it('revoke', () => {
+		expect(teamInvitationsKeys.revoke('team-1')).toEqual([
+			'teams',
+			'invitations',
+			'revoke',
+			'team-1',
+		])
+	})
+
+	it('myLists', () => {
+		expect(teamInvitationsKeys.myLists()).toEqual(['teams', 'invitations', 'my-list'])
+	})
+
+	it('myList', () => {
+		expect(teamInvitationsKeys.myList()).toEqual(['teams', 'invitations', 'my-list'])
+	})
+
+	it('accept', () => {
+		expect(teamInvitationsKeys.accept()).toEqual(['teams', 'invitations', 'accept'])
+	})
+
+	it('decline', () => {
+		expect(teamInvitationsKeys.decline()).toEqual(['teams', 'invitations', 'decline'])
+	})
+})

--- a/apps/web/test/unit/shared/api/team-members-keys.spec.ts
+++ b/apps/web/test/unit/shared/api/team-members-keys.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { teamMembersKeys } from '@/shared/api/use-team-members'
+
+describe('teamMembersKeys', () => {
+	it('all', () => {
+		expect(teamMembersKeys.all).toEqual(['teams', 'members'])
+	})
+
+	it('lists', () => {
+		expect(teamMembersKeys.lists()).toEqual(['teams', 'members', 'list'])
+	})
+
+	it('list', () => {
+		expect(teamMembersKeys.list('team-1')).toEqual(['teams', 'members', 'list', 'team-1'])
+	})
+
+	it('changeRole', () => {
+		expect(teamMembersKeys.changeRole('team-1')).toEqual([
+			'teams',
+			'members',
+			'change-role',
+			'team-1',
+		])
+	})
+
+	it('remove', () => {
+		expect(teamMembersKeys.remove('team-1')).toEqual([
+			'teams',
+			'members',
+			'remove',
+			'team-1',
+		])
+	})
+})

--- a/apps/web/test/unit/shared/api/use-auth.spec.tsx
+++ b/apps/web/test/unit/shared/api/use-auth.spec.tsx
@@ -16,9 +16,13 @@ vi.mock('@/shared/lib/api/auth-service', () => ({
 }))
 
 const createWrapper = (queryClient: QueryClient) => {
-	return ({ children }: React.PropsWithChildren) => (
+	const QueryClientWrapper = ({ children }: React.PropsWithChildren) => (
 		<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 	)
+
+	QueryClientWrapper.displayName = 'UseAuthQueryClientWrapper'
+
+	return QueryClientWrapper
 }
 
 describe('use-auth hooks', () => {

--- a/apps/web/test/unit/shared/api/use-team-invitations.spec.tsx
+++ b/apps/web/test/unit/shared/api/use-team-invitations.spec.tsx
@@ -1,0 +1,142 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+	teamInvitationsKeys,
+	useAcceptInvitation,
+	useMyInvitations,
+	useTeamInvitations,
+} from '@/shared/api/use-team-invitations'
+import { teamsKeys } from '@/shared/api/use-teams'
+import {
+	teamInvitationsService,
+	type MyInvitation,
+	type Team,
+	type TeamInvitation,
+} from '@/shared/lib/api/team-invitations-service'
+
+vi.mock('@/shared/lib/api/team-invitations-service', () => ({
+	teamInvitationsService: {
+		sendInvitation: vi.fn(),
+		getTeamInvitations: vi.fn(),
+		revokeInvitation: vi.fn(),
+		getMyInvitations: vi.fn(),
+		acceptInvitation: vi.fn(),
+		declineInvitation: vi.fn(),
+	},
+}))
+
+describe('use-team-invitations hooks', () => {
+	let queryClient: QueryClient
+
+	const createWrapper = () => {
+		queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		})
+
+		return ({ children }: React.PropsWithChildren) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		)
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('useTeamInvitations запрашивает invitations команды', async () => {
+		vi.mocked(teamInvitationsService.getTeamInvitations).mockResolvedValue([
+			{
+				id: 'inv-1',
+				teamId: 'team-1',
+				invitedById: 'user-1',
+				email: 'new@test.com',
+				role: 'ADMIN',
+				status: 'PENDING',
+				token: 'token-1',
+				expiresAt: '2026-04-11T12:00:00.000Z',
+				createdAt: '2026-04-09T12:00:00.000Z',
+				updatedAt: '2026-04-09T12:00:00.000Z',
+				team: { id: 'team-1', name: 'Dream Team', avatarUrl: null },
+				invitedBy: { id: 'user-1', name: 'Alex', email: 'alex@test.com' },
+			},
+		] as TeamInvitation[])
+
+		const { result } = renderHook(() => useTeamInvitations('team-1'), {
+			wrapper: createWrapper(),
+		})
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+		expect(teamInvitationsService.getTeamInvitations).toHaveBeenCalledWith('team-1')
+		expect(result.current.data).toHaveLength(1)
+	})
+
+	it('useMyInvitations запрашивает входящие invitations', async () => {
+		vi.mocked(teamInvitationsService.getMyInvitations).mockResolvedValue([
+			{
+				id: 'inv-1',
+				email: 'new@test.com',
+				role: 'MEMBER',
+				token: 'token-1',
+				expiresAt: '2026-04-11T12:00:00.000Z',
+				createdAt: '2026-04-09T12:00:00.000Z',
+				team: { id: 'team-1', name: 'Dream Team', avatarUrl: null },
+				invitedBy: { id: 'user-1', name: 'Alex', email: 'alex@test.com' },
+			},
+		] as MyInvitation[])
+
+		const { result } = renderHook(() => useMyInvitations(), {
+			wrapper: createWrapper(),
+		})
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+		expect(teamInvitationsService.getMyInvitations).toHaveBeenCalledOnce()
+		expect(result.current.data).toHaveLength(1)
+	})
+
+	it('useAcceptInvitation кладёт команду в detail cache и инвалидирует списки', async () => {
+		vi.mocked(teamInvitationsService.acceptInvitation).mockResolvedValue({
+			id: 'team-1',
+			name: 'Dream Team',
+			description: null,
+			avatarUrl: null,
+			createdAt: '2024-01-01',
+			updatedAt: '2024-01-02',
+			members: [],
+		} as Team)
+
+		const invalidateSpy = vi.spyOn(QueryClient.prototype, 'invalidateQueries')
+
+		const { result } = renderHook(() => useAcceptInvitation(), {
+			wrapper: createWrapper(),
+		})
+
+		result.current.mutate('token-1')
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+		expect(teamInvitationsService.acceptInvitation).toHaveBeenCalledWith(
+			'token-1',
+			expect.anything(),
+		)
+		expect(queryClient.getQueryData(teamsKeys.detail('team-1'))).toEqual({
+			id: 'team-1',
+			name: 'Dream Team',
+			description: null,
+			avatarUrl: null,
+			createdAt: '2024-01-01',
+			updatedAt: '2024-01-02',
+			members: [],
+		})
+		expect(invalidateSpy).toHaveBeenCalledWith({
+			queryKey: teamsKeys.lists(),
+		})
+		expect(invalidateSpy).toHaveBeenCalledWith({
+			queryKey: teamInvitationsKeys.myList(),
+		})
+
+		invalidateSpy.mockRestore()
+	})
+})

--- a/apps/web/test/unit/shared/api/use-team-invitations.spec.tsx
+++ b/apps/web/test/unit/shared/api/use-team-invitations.spec.tsx
@@ -32,9 +32,13 @@ describe('use-team-invitations hooks', () => {
 			defaultOptions: { queries: { retry: false } },
 		})
 
-		return ({ children }: React.PropsWithChildren) => (
+		const QueryClientWrapper = ({ children }: React.PropsWithChildren) => (
 			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 		)
+
+		QueryClientWrapper.displayName = 'UseTeamInvitationsQueryClientWrapper'
+
+		return QueryClientWrapper
 	}
 
 	beforeEach(() => {

--- a/apps/web/test/unit/shared/api/use-team-invitations.spec.tsx
+++ b/apps/web/test/unit/shared/api/use-team-invitations.spec.tsx
@@ -1,3 +1,14 @@
+import '@/test/mocks/api/team-invitations-service.mock'
+
+import {
+	createMyInvitationFixture,
+	createTeamFixture,
+	createTeamInvitationFixture,
+} from '@/test/mocks/api/team-api.fixtures'
+import {
+	resetTeamInvitationsServiceMock,
+	teamInvitationsServiceMock,
+} from '@/test/mocks/api/team-invitations-service.mock'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -5,27 +16,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
 	teamInvitationsKeys,
 	useAcceptInvitation,
+	useDeclineInvitation,
 	useMyInvitations,
+	useRevokeTeamInvitation,
+	useSendTeamInvitation,
 	useTeamInvitations,
 } from '@/shared/api/use-team-invitations'
 import { teamsKeys } from '@/shared/api/use-teams'
-import {
-	teamInvitationsService,
-	type MyInvitation,
-	type Team,
-	type TeamInvitation,
-} from '@/shared/lib/api/team-invitations-service'
-
-vi.mock('@/shared/lib/api/team-invitations-service', () => ({
-	teamInvitationsService: {
-		sendInvitation: vi.fn(),
-		getTeamInvitations: vi.fn(),
-		revokeInvitation: vi.fn(),
-		getMyInvitations: vi.fn(),
-		acceptInvitation: vi.fn(),
-		declineInvitation: vi.fn(),
-	},
-}))
 
 describe('use-team-invitations hooks', () => {
 	let queryClient: QueryClient
@@ -41,26 +38,15 @@ describe('use-team-invitations hooks', () => {
 	}
 
 	beforeEach(() => {
-		vi.clearAllMocks()
+		resetTeamInvitationsServiceMock()
 	})
 
 	it('useTeamInvitations запрашивает invitations команды', async () => {
-		vi.mocked(teamInvitationsService.getTeamInvitations).mockResolvedValue([
-			{
-				id: 'inv-1',
-				teamId: 'team-1',
-				invitedById: 'user-1',
-				email: 'new@test.com',
+		teamInvitationsServiceMock.getTeamInvitations.mockResolvedValue([
+			createTeamInvitationFixture({
 				role: 'ADMIN',
-				status: 'PENDING',
-				token: 'token-1',
-				expiresAt: '2026-04-11T12:00:00.000Z',
-				createdAt: '2026-04-09T12:00:00.000Z',
-				updatedAt: '2026-04-09T12:00:00.000Z',
-				team: { id: 'team-1', name: 'Dream Team', avatarUrl: null },
-				invitedBy: { id: 'user-1', name: 'Alex', email: 'alex@test.com' },
-			},
-		] as TeamInvitation[])
+			}),
+		])
 
 		const { result } = renderHook(() => useTeamInvitations('team-1'), {
 			wrapper: createWrapper(),
@@ -68,23 +54,14 @@ describe('use-team-invitations hooks', () => {
 
 		await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
-		expect(teamInvitationsService.getTeamInvitations).toHaveBeenCalledWith('team-1')
+		expect(teamInvitationsServiceMock.getTeamInvitations).toHaveBeenCalledWith('team-1')
 		expect(result.current.data).toHaveLength(1)
 	})
 
 	it('useMyInvitations запрашивает входящие invitations', async () => {
-		vi.mocked(teamInvitationsService.getMyInvitations).mockResolvedValue([
-			{
-				id: 'inv-1',
-				email: 'new@test.com',
-				role: 'MEMBER',
-				token: 'token-1',
-				expiresAt: '2026-04-11T12:00:00.000Z',
-				createdAt: '2026-04-09T12:00:00.000Z',
-				team: { id: 'team-1', name: 'Dream Team', avatarUrl: null },
-				invitedBy: { id: 'user-1', name: 'Alex', email: 'alex@test.com' },
-			},
-		] as MyInvitation[])
+		teamInvitationsServiceMock.getMyInvitations.mockResolvedValue([
+			createMyInvitationFixture(),
+		])
 
 		const { result } = renderHook(() => useMyInvitations(), {
 			wrapper: createWrapper(),
@@ -92,20 +69,45 @@ describe('use-team-invitations hooks', () => {
 
 		await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
-		expect(teamInvitationsService.getMyInvitations).toHaveBeenCalledOnce()
+		expect(teamInvitationsServiceMock.getMyInvitations).toHaveBeenCalledOnce()
 		expect(result.current.data).toHaveLength(1)
 	})
 
+	it('useSendTeamInvitation инвалидирует список приглашений команды', async () => {
+		teamInvitationsServiceMock.sendInvitation.mockResolvedValue(
+			createTeamInvitationFixture(),
+		)
+
+		const invalidateSpy = vi.spyOn(QueryClient.prototype, 'invalidateQueries')
+
+		const { result } = renderHook(() => useSendTeamInvitation('team-1'), {
+			wrapper: createWrapper(),
+		})
+
+		result.current.mutate({ email: 'new@test.com', role: 'MEMBER' })
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+		expect(teamInvitationsServiceMock.sendInvitation).toHaveBeenCalledWith('team-1', {
+			email: 'new@test.com',
+			role: 'MEMBER',
+		})
+		expect(invalidateSpy).toHaveBeenCalledWith({
+			queryKey: teamInvitationsKeys.teamList('team-1'),
+		})
+
+		invalidateSpy.mockRestore()
+	})
+
 	it('useAcceptInvitation кладёт команду в detail cache и инвалидирует списки', async () => {
-		vi.mocked(teamInvitationsService.acceptInvitation).mockResolvedValue({
-			id: 'team-1',
-			name: 'Dream Team',
-			description: null,
-			avatarUrl: null,
-			createdAt: '2024-01-01',
-			updatedAt: '2024-01-02',
-			members: [],
-		} as Team)
+		teamInvitationsServiceMock.acceptInvitation.mockResolvedValue(
+			createTeamFixture({
+				id: 'team-1',
+				name: 'Dream Team',
+				updatedAt: '2024-01-02',
+				members: [],
+			}),
+		)
 
 		const invalidateSpy = vi.spyOn(QueryClient.prototype, 'invalidateQueries')
 
@@ -117,7 +119,7 @@ describe('use-team-invitations hooks', () => {
 
 		await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
-		expect(teamInvitationsService.acceptInvitation).toHaveBeenCalledWith(
+		expect(teamInvitationsServiceMock.acceptInvitation).toHaveBeenCalledWith(
 			'token-1',
 			expect.anything(),
 		)
@@ -133,6 +135,64 @@ describe('use-team-invitations hooks', () => {
 		expect(invalidateSpy).toHaveBeenCalledWith({
 			queryKey: teamsKeys.lists(),
 		})
+		expect(invalidateSpy).toHaveBeenCalledWith({
+			queryKey: teamInvitationsKeys.myList(),
+		})
+
+		invalidateSpy.mockRestore()
+	})
+
+	it('useRevokeTeamInvitation инвалидирует список приглашений команды', async () => {
+		teamInvitationsServiceMock.revokeInvitation.mockResolvedValue(
+			createTeamInvitationFixture({
+				status: 'DECLINED',
+				updatedAt: '2026-04-09T12:05:00.000Z',
+			}),
+		)
+
+		const invalidateSpy = vi.spyOn(QueryClient.prototype, 'invalidateQueries')
+
+		const { result } = renderHook(() => useRevokeTeamInvitation('team-1'), {
+			wrapper: createWrapper(),
+		})
+
+		result.current.mutate('inv-1')
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+		expect(teamInvitationsServiceMock.revokeInvitation).toHaveBeenCalledWith(
+			'team-1',
+			'inv-1',
+		)
+		expect(invalidateSpy).toHaveBeenCalledWith({
+			queryKey: teamInvitationsKeys.teamList('team-1'),
+		})
+
+		invalidateSpy.mockRestore()
+	})
+
+	it('useDeclineInvitation инвалидирует список моих приглашений', async () => {
+		teamInvitationsServiceMock.declineInvitation.mockResolvedValue(
+			createTeamInvitationFixture({
+				status: 'DECLINED',
+				updatedAt: '2026-04-09T12:05:00.000Z',
+			}),
+		)
+
+		const invalidateSpy = vi.spyOn(QueryClient.prototype, 'invalidateQueries')
+
+		const { result } = renderHook(() => useDeclineInvitation(), {
+			wrapper: createWrapper(),
+		})
+
+		result.current.mutate('token-1')
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+		expect(teamInvitationsServiceMock.declineInvitation).toHaveBeenCalledWith(
+			'token-1',
+			expect.anything(),
+		)
 		expect(invalidateSpy).toHaveBeenCalledWith({
 			queryKey: teamInvitationsKeys.myList(),
 		})

--- a/apps/web/test/unit/shared/api/use-team-invitations.spec.tsx
+++ b/apps/web/test/unit/shared/api/use-team-invitations.spec.tsx
@@ -62,6 +62,15 @@ describe('use-team-invitations hooks', () => {
 		expect(result.current.data).toHaveLength(1)
 	})
 
+	it('useTeamInvitations не делает запрос без teamId', () => {
+		const { result } = renderHook(() => useTeamInvitations(''), {
+			wrapper: createWrapper(),
+		})
+
+		expect(teamInvitationsServiceMock.getTeamInvitations).not.toHaveBeenCalled()
+		expect(result.current.fetchStatus).toBe('idle')
+	})
+
 	it('useMyInvitations запрашивает входящие invitations', async () => {
 		teamInvitationsServiceMock.getMyInvitations.mockResolvedValue([
 			createMyInvitationFixture(),

--- a/apps/web/test/unit/shared/api/use-team-members.spec.tsx
+++ b/apps/web/test/unit/shared/api/use-team-members.spec.tsx
@@ -60,6 +60,15 @@ describe('use-team-members hooks', () => {
 		expect(result.current.data).toHaveLength(1)
 	})
 
+	it('useTeamMembers не делает запрос без teamId', () => {
+		const { result } = renderHook(() => useTeamMembers(''), {
+			wrapper: createWrapper(),
+		})
+
+		expect(teamMembersServiceMock.getMembers).not.toHaveBeenCalled()
+		expect(result.current.fetchStatus).toBe('idle')
+	})
+
 	it('useChangeMemberRole инвалидирует members/detail/list кэш', async () => {
 		teamMembersServiceMock.changeRole.mockResolvedValue(
 			createTeamMemberFixture({

--- a/apps/web/test/unit/shared/api/use-team-members.spec.tsx
+++ b/apps/web/test/unit/shared/api/use-team-members.spec.tsx
@@ -1,0 +1,101 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+	teamMembersKeys,
+	useChangeMemberRole,
+	useTeamMembers,
+} from '@/shared/api/use-team-members'
+import { teamsKeys } from '@/shared/api/use-teams'
+import {
+	teamMembersService,
+	type TeamMember,
+} from '@/shared/lib/api/team-members-service'
+
+vi.mock('@/shared/lib/api/team-members-service', () => ({
+	teamMembersService: {
+		getMembers: vi.fn(),
+		changeRole: vi.fn(),
+		removeMember: vi.fn(),
+	},
+}))
+
+describe('use-team-members hooks', () => {
+	let queryClient: QueryClient
+
+	const createWrapper = () => {
+		queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		})
+
+		return ({ children }: React.PropsWithChildren) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		)
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('useTeamMembers запрашивает участников команды', async () => {
+		vi.mocked(teamMembersService.getMembers).mockResolvedValue([
+			{
+				id: 'member-1',
+				userId: 'user-1',
+				name: 'Alex',
+				email: 'alex@test.com',
+				role: 'ADMIN',
+				joinedAt: '2024-02-01',
+			},
+		] as TeamMember[])
+
+		const { result } = renderHook(() => useTeamMembers('team-1'), {
+			wrapper: createWrapper(),
+		})
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+		expect(teamMembersService.getMembers).toHaveBeenCalledWith('team-1')
+		expect(result.current.data).toHaveLength(1)
+	})
+
+	it('useChangeMemberRole инвалидирует members/detail/list кэш', async () => {
+		vi.mocked(teamMembersService.changeRole).mockResolvedValue({
+			id: 'member-1',
+			userId: 'user-1',
+			name: 'Alex',
+			email: 'alex@test.com',
+			role: 'MEMBER',
+			joinedAt: '2024-02-01',
+		} as TeamMember)
+
+		const invalidateSpy = vi.spyOn(QueryClient.prototype, 'invalidateQueries')
+
+		const { result } = renderHook(() => useChangeMemberRole('team-1'), {
+			wrapper: createWrapper(),
+		})
+
+		result.current.mutate({
+			userId: 'user-1',
+			data: { role: 'MEMBER' },
+		})
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+		expect(teamMembersService.changeRole).toHaveBeenCalledWith('team-1', 'user-1', {
+			role: 'MEMBER',
+		})
+		expect(invalidateSpy).toHaveBeenCalledWith({
+			queryKey: teamMembersKeys.list('team-1'),
+		})
+		expect(invalidateSpy).toHaveBeenCalledWith({
+			queryKey: teamsKeys.detail('team-1'),
+		})
+		expect(invalidateSpy).toHaveBeenCalledWith({
+			queryKey: teamsKeys.lists(),
+		})
+
+		invalidateSpy.mockRestore()
+	})
+})

--- a/apps/web/test/unit/shared/api/use-team-members.spec.tsx
+++ b/apps/web/test/unit/shared/api/use-team-members.spec.tsx
@@ -1,3 +1,10 @@
+import '@/test/mocks/api/team-members-service.mock'
+
+import { createTeamMemberFixture } from '@/test/mocks/api/team-api.fixtures'
+import {
+	resetTeamMembersServiceMock,
+	teamMembersServiceMock,
+} from '@/test/mocks/api/team-members-service.mock'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -5,21 +12,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
 	teamMembersKeys,
 	useChangeMemberRole,
+	useRemoveTeamMember,
 	useTeamMembers,
 } from '@/shared/api/use-team-members'
 import { teamsKeys } from '@/shared/api/use-teams'
-import {
-	teamMembersService,
-	type TeamMember,
-} from '@/shared/lib/api/team-members-service'
-
-vi.mock('@/shared/lib/api/team-members-service', () => ({
-	teamMembersService: {
-		getMembers: vi.fn(),
-		changeRole: vi.fn(),
-		removeMember: vi.fn(),
-	},
-}))
 
 describe('use-team-members hooks', () => {
 	let queryClient: QueryClient
@@ -35,20 +31,20 @@ describe('use-team-members hooks', () => {
 	}
 
 	beforeEach(() => {
-		vi.clearAllMocks()
+		resetTeamMembersServiceMock()
 	})
 
 	it('useTeamMembers запрашивает участников команды', async () => {
-		vi.mocked(teamMembersService.getMembers).mockResolvedValue([
-			{
+		teamMembersServiceMock.getMembers.mockResolvedValue([
+			createTeamMemberFixture({
 				id: 'member-1',
 				userId: 'user-1',
 				name: 'Alex',
 				email: 'alex@test.com',
 				role: 'ADMIN',
 				joinedAt: '2024-02-01',
-			},
-		] as TeamMember[])
+			}),
+		])
 
 		const { result } = renderHook(() => useTeamMembers('team-1'), {
 			wrapper: createWrapper(),
@@ -56,19 +52,21 @@ describe('use-team-members hooks', () => {
 
 		await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
-		expect(teamMembersService.getMembers).toHaveBeenCalledWith('team-1')
+		expect(teamMembersServiceMock.getMembers).toHaveBeenCalledWith('team-1')
 		expect(result.current.data).toHaveLength(1)
 	})
 
 	it('useChangeMemberRole инвалидирует members/detail/list кэш', async () => {
-		vi.mocked(teamMembersService.changeRole).mockResolvedValue({
-			id: 'member-1',
-			userId: 'user-1',
-			name: 'Alex',
-			email: 'alex@test.com',
-			role: 'MEMBER',
-			joinedAt: '2024-02-01',
-		} as TeamMember)
+		teamMembersServiceMock.changeRole.mockResolvedValue(
+			createTeamMemberFixture({
+				id: 'member-1',
+				userId: 'user-1',
+				name: 'Alex',
+				email: 'alex@test.com',
+				role: 'MEMBER',
+				joinedAt: '2024-02-01',
+			}),
+		)
 
 		const invalidateSpy = vi.spyOn(QueryClient.prototype, 'invalidateQueries')
 
@@ -83,9 +81,39 @@ describe('use-team-members hooks', () => {
 
 		await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
-		expect(teamMembersService.changeRole).toHaveBeenCalledWith('team-1', 'user-1', {
+		expect(teamMembersServiceMock.changeRole).toHaveBeenCalledWith('team-1', 'user-1', {
 			role: 'MEMBER',
 		})
+		expect(invalidateSpy).toHaveBeenCalledWith({
+			queryKey: teamMembersKeys.list('team-1'),
+		})
+		expect(invalidateSpy).toHaveBeenCalledWith({
+			queryKey: teamsKeys.detail('team-1'),
+		})
+		expect(invalidateSpy).toHaveBeenCalledWith({
+			queryKey: teamsKeys.lists(),
+		})
+
+		invalidateSpy.mockRestore()
+	})
+
+	it('useRemoveTeamMember инвалидирует members/detail/list кэш', async () => {
+		teamMembersServiceMock.removeMember.mockResolvedValue({
+			message: 'Участник успешно исключён',
+			success: true,
+		})
+
+		const invalidateSpy = vi.spyOn(QueryClient.prototype, 'invalidateQueries')
+
+		const { result } = renderHook(() => useRemoveTeamMember('team-1'), {
+			wrapper: createWrapper(),
+		})
+
+		result.current.mutate('user-1')
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+		expect(teamMembersServiceMock.removeMember).toHaveBeenCalledWith('team-1', 'user-1')
 		expect(invalidateSpy).toHaveBeenCalledWith({
 			queryKey: teamMembersKeys.list('team-1'),
 		})

--- a/apps/web/test/unit/shared/api/use-team-members.spec.tsx
+++ b/apps/web/test/unit/shared/api/use-team-members.spec.tsx
@@ -25,9 +25,13 @@ describe('use-team-members hooks', () => {
 			defaultOptions: { queries: { retry: false } },
 		})
 
-		return ({ children }: React.PropsWithChildren) => (
+		const QueryClientWrapper = ({ children }: React.PropsWithChildren) => (
 			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 		)
+
+		QueryClientWrapper.displayName = 'UseTeamMembersQueryClientWrapper'
+
+		return QueryClientWrapper
 	}
 
 	beforeEach(() => {

--- a/apps/web/test/unit/shared/api/use-teams.spec.tsx
+++ b/apps/web/test/unit/shared/api/use-teams.spec.tsx
@@ -33,9 +33,13 @@ describe('use-teams hooks', () => {
 			},
 		})
 
-		return ({ children }: React.PropsWithChildren) => (
+		const QueryClientWrapper = ({ children }: React.PropsWithChildren) => (
 			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 		)
+
+		QueryClientWrapper.displayName = 'UseTeamsQueryClientWrapper'
+
+		return QueryClientWrapper
 	}
 
 	beforeEach(() => {
@@ -177,11 +181,15 @@ describe('use-teams hooks', () => {
 
 			const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
 
-			const wrapper = ({ children }: React.PropsWithChildren) => (
+			const DeleteTeamQueryClientWrapper = ({ children }: React.PropsWithChildren) => (
 				<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 			)
 
-			const { result } = renderHook(() => useDeleteTeam(), { wrapper })
+			DeleteTeamQueryClientWrapper.displayName = 'UseDeleteTeamQueryClientWrapper'
+
+			const { result } = renderHook(() => useDeleteTeam(), {
+				wrapper: DeleteTeamQueryClientWrapper,
+			})
 
 			result.current.mutate('team-1')
 

--- a/apps/web/test/unit/shared/api/use-teams.spec.tsx
+++ b/apps/web/test/unit/shared/api/use-teams.spec.tsx
@@ -1,54 +1,103 @@
+import '@/test/mocks/api/teams-service.mock'
+
+import {
+	createDeleteTeamResponseFixture,
+	createTeamFixture,
+	createTeamListItemFixture,
+} from '@/test/mocks/api/team-api.fixtures'
+import {
+	resetTeamsServiceMock,
+	teamsServiceMock,
+} from '@/test/mocks/api/teams-service.mock'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { teamsKeys, useCreateTeam, useTeamsList } from '@/shared/api/use-teams'
-import { Team, TeamListItem, teamsService } from '@/shared/lib/api/teams-service'
-
-vi.mock('@/shared/lib/api/teams-service', () => ({
-	teamsService: {
-		getAll: vi.fn(),
-		getById: vi.fn(),
-		create: vi.fn(),
-		update: vi.fn(),
-		delete: vi.fn(),
-	},
-}))
+import {
+	teamsKeys,
+	useCreateTeam,
+	useDeleteTeam,
+	useTeamDetail,
+	useTeamsList,
+	useUpdateTeam,
+} from '@/shared/api/use-teams'
 
 describe('use-teams hooks', () => {
 	let queryClient: QueryClient
 
 	const createWrapper = () => {
 		queryClient = new QueryClient({
-			defaultOptions: { queries: { retry: false } },
+			defaultOptions: {
+				queries: { retry: false },
+				mutations: { retry: false },
+			},
 		})
+
 		return ({ children }: React.PropsWithChildren) => (
 			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 		)
 	}
 
 	beforeEach(() => {
-		vi.clearAllMocks()
+		resetTeamsServiceMock()
 	})
 
 	describe('useTeamsList', () => {
 		it('запрашивает список команд', async () => {
-			const mockTeams = [{ id: '1', name: 'Team A' }]
-			vi.mocked(teamsService.getAll).mockResolvedValue(mockTeams as TeamListItem[])
+			const teams = [
+				createTeamListItemFixture({
+					id: 'team-1',
+					name: 'Team A',
+				}),
+			]
+
+			teamsServiceMock.getAll.mockResolvedValue(teams)
 
 			const { result } = renderHook(() => useTeamsList(), { wrapper: createWrapper() })
 
 			await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
-			expect(teamsService.getAll).toHaveBeenCalledOnce()
-			expect(result.current.data).toEqual(mockTeams)
+			expect(teamsServiceMock.getAll).toHaveBeenCalledOnce()
+			expect(result.current.data).toEqual(teams)
+		})
+	})
+
+	describe('useTeamDetail', () => {
+		it('запрашивает команду по id, если он передан', async () => {
+			const team = createTeamFixture({
+				id: 'team-1',
+				name: 'Alpha Team',
+			})
+
+			teamsServiceMock.getById.mockResolvedValue(team)
+
+			const { result } = renderHook(() => useTeamDetail('team-1'), {
+				wrapper: createWrapper(),
+			})
+
+			await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+			expect(teamsServiceMock.getById).toHaveBeenCalledWith('team-1')
+			expect(result.current.data).toEqual(team)
+		})
+
+		it('не делает запрос, если id пустой', async () => {
+			const { result } = renderHook(() => useTeamDetail(''), {
+				wrapper: createWrapper(),
+			})
+
+			expect(teamsServiceMock.getById).not.toHaveBeenCalled()
+			expect(result.current.fetchStatus).toBe('idle')
 		})
 	})
 
 	describe('useCreateTeam', () => {
 		it('после создания команды обновляет кэш (setQueryData) и инвалидирует список', async () => {
-			const newTeam = { id: 'team-1', name: 'New Team' }
-			vi.mocked(teamsService.create).mockResolvedValue(newTeam as Team)
+			const team = createTeamFixture({
+				id: 'team-1',
+				name: 'New Team',
+			})
+			teamsServiceMock.create.mockResolvedValue(team)
 
 			const invalidateSpy = vi.spyOn(QueryClient.prototype, 'invalidateQueries')
 
@@ -58,15 +107,89 @@ describe('use-teams hooks', () => {
 
 			await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
-			expect(teamsService.create).toHaveBeenCalledWith(
+			expect(teamsServiceMock.create).toHaveBeenCalledWith(
 				{ name: 'New Team' },
 				expect.anything(),
 			)
-
-			const cachedTeam = queryClient.getQueryData(teamsKeys.detail('team-1'))
-			expect(cachedTeam).toEqual(newTeam)
-
+			expect(queryClient.getQueryData(teamsKeys.detail('team-1'))).toEqual(team)
 			expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: teamsKeys.lists() })
+
+			invalidateSpy.mockRestore()
+		})
+	})
+
+	describe('useUpdateTeam', () => {
+		it('обновляет кэш команды и инвалидирует список и detail', async () => {
+			const team = createTeamFixture({
+				id: 'team-1',
+				name: 'Updated Team',
+				description: 'Refined description',
+			})
+
+			teamsServiceMock.update.mockResolvedValue(team)
+
+			const invalidateSpy = vi.spyOn(QueryClient.prototype, 'invalidateQueries')
+
+			const { result } = renderHook(() => useUpdateTeam(), {
+				wrapper: createWrapper(),
+			})
+
+			result.current.mutate({
+				id: 'team-1',
+				data: {
+					name: 'Updated Team',
+					description: 'Refined description',
+				},
+			})
+
+			await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+			expect(teamsServiceMock.update).toHaveBeenCalledWith('team-1', {
+				name: 'Updated Team',
+				description: 'Refined description',
+			})
+			expect(queryClient.getQueryData(teamsKeys.detail('team-1'))).toEqual(team)
+			expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: teamsKeys.lists() })
+			expect(invalidateSpy).toHaveBeenCalledWith({
+				queryKey: teamsKeys.detail('team-1'),
+			})
+
+			invalidateSpy.mockRestore()
+		})
+	})
+
+	describe('useDeleteTeam', () => {
+		it('инвалидирует список и удаляет detail из кэша', async () => {
+			const team = createTeamFixture({
+				id: 'team-1',
+				name: 'Alpha Team',
+			})
+
+			queryClient = new QueryClient({
+				defaultOptions: {
+					queries: { retry: false },
+					mutations: { retry: false },
+				},
+			})
+			queryClient.setQueryData(teamsKeys.detail(team.id), team)
+
+			teamsServiceMock.delete.mockResolvedValue(createDeleteTeamResponseFixture())
+
+			const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+			const wrapper = ({ children }: React.PropsWithChildren) => (
+				<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+			)
+
+			const { result } = renderHook(() => useDeleteTeam(), { wrapper })
+
+			result.current.mutate('team-1')
+
+			await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+			expect(teamsServiceMock.delete).toHaveBeenCalledWith('team-1', expect.anything())
+			expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: teamsKeys.lists() })
+			expect(queryClient.getQueryData(teamsKeys.detail('team-1'))).toBeUndefined()
 
 			invalidateSpy.mockRestore()
 		})

--- a/apps/web/test/unit/shared/lib/api/team-invitations-service.spec.ts
+++ b/apps/web/test/unit/shared/lib/api/team-invitations-service.spec.ts
@@ -1,61 +1,30 @@
-import { AxiosHeaders, type AxiosResponse } from 'axios'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import '@/test/mocks/api/http-client.mock'
+
+import { mockApiClient, resetApiClientMock } from '@/test/mocks/api/http-client.mock'
+import {
+	axiosResponse,
+	createMyInvitationApiFixture,
+	createMyInvitationFixture,
+	createNestedTeamMemberApiFixture,
+	createTeamApiFixture,
+	createTeamInvitationApiFixture,
+} from '@/test/mocks/api/team-api.fixtures'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import { teamInvitationsService } from '@/shared/lib/api/team-invitations-service'
 
-const { mockGet, mockPost, mockDelete } = vi.hoisted(() => ({
-	mockGet: vi.fn(),
-	mockPost: vi.fn(),
-	mockDelete: vi.fn(),
-}))
-
-vi.mock('@/shared/lib/api/client', () => ({
-	client: {
-		get: mockGet,
-		post: mockPost,
-		delete: mockDelete,
-	},
-}))
-
-function axiosResponse<T>(data: T): AxiosResponse<T> {
-	return {
-		data,
-		status: 200,
-		statusText: 'OK',
-		headers: {},
-		config: { headers: new AxiosHeaders() },
-	}
-}
-
 describe('teamInvitationsService', () => {
 	beforeEach(() => {
-		vi.clearAllMocks()
+		resetApiClientMock()
 	})
 
 	it('sendInvitation отправляет запрос и нормализует invitation response', async () => {
-		mockPost.mockResolvedValue(
-			axiosResponse({
-				id: 'inv-1',
-				teamId: 'team-1',
-				invitedById: 'user-1',
-				email: 'new@test.com',
-				role: 'ADMIN',
-				status: 'PENDING',
-				token: 'token-1',
-				expiresAt: '2026-04-11T12:00:00.000Z',
-				createdAt: '2026-04-09T12:00:00.000Z',
-				updatedAt: '2026-04-09T12:00:00.000Z',
-				team: {
-					id: 'team-1',
-					name: 'Dream Team',
-					avatarUrl: null,
-				},
-				invitedBy: {
-					id: 'user-1',
-					name: 'Alex',
-					email: 'alex@test.com',
-				},
-			}),
+		mockApiClient.post.mockResolvedValue(
+			axiosResponse(
+				createTeamInvitationApiFixture({
+					role: 'ADMIN',
+				}),
+			),
 		)
 
 		const result = await teamInvitationsService.sendInvitation('team-1', {
@@ -63,7 +32,7 @@ describe('teamInvitationsService', () => {
 			role: 'ADMIN',
 		})
 
-		expect(mockPost).toHaveBeenCalledWith('/teams/team-1/invitations', {
+		expect(mockApiClient.post).toHaveBeenCalledWith('/teams/team-1/invitations', {
 			email: 'new@test.com',
 			role: 'ADMIN',
 		})
@@ -71,82 +40,49 @@ describe('teamInvitationsService', () => {
 		expect(result.invitedBy.email).toBe('alex@test.com')
 	})
 
-	it('getMyInvitations нормализует список входящих invitations', async () => {
-		mockGet.mockResolvedValue(
-			axiosResponse([
-				{
-					id: 'inv-1',
-					email: 'new@test.com',
-					role: 'MEMBER',
-					token: 'token-1',
-					expiresAt: '2026-04-11T12:00:00.000Z',
-					createdAt: '2026-04-09T12:00:00.000Z',
-					team: {
-						id: 'team-1',
-						name: 'Dream Team',
-						avatarUrl: null,
-					},
-					invitedBy: {
-						id: 'user-1',
-						name: 'Alex',
-						email: 'alex@test.com',
-					},
-				},
-			]),
+	it('getTeamInvitations загружает список приглашений команды и нормализует его', async () => {
+		mockApiClient.get.mockResolvedValue(
+			axiosResponse([createTeamInvitationApiFixture({ role: 'ADMIN' })]),
 		)
+
+		const result = await teamInvitationsService.getTeamInvitations('team-1')
+
+		expect(mockApiClient.get).toHaveBeenCalledWith('/teams/team-1/invitations')
+		expect(result).toHaveLength(1)
+		expect(result[0]).toMatchObject({
+			id: 'inv-1',
+			status: 'PENDING',
+			team: { id: 'team-1', name: 'Dream Team', avatarUrl: null },
+		})
+	})
+
+	it('getMyInvitations нормализует список входящих invitations', async () => {
+		mockApiClient.get.mockResolvedValue(axiosResponse([createMyInvitationApiFixture()]))
 
 		const result = await teamInvitationsService.getMyInvitations()
 
-		expect(mockGet).toHaveBeenCalledWith('/invitations/me')
-		expect(result).toEqual([
-			{
-				id: 'inv-1',
-				email: 'new@test.com',
-				role: 'MEMBER',
-				token: 'token-1',
-				expiresAt: '2026-04-11T12:00:00.000Z',
-				createdAt: '2026-04-09T12:00:00.000Z',
-				team: {
-					id: 'team-1',
-					name: 'Dream Team',
-					avatarUrl: null,
-				},
-				invitedBy: {
-					id: 'user-1',
-					name: 'Alex',
-					email: 'alex@test.com',
-				},
-			},
-		])
+		expect(mockApiClient.get).toHaveBeenCalledWith('/invitations/me')
+		expect(result).toEqual([createMyInvitationFixture()])
 	})
 
 	it('acceptInvitation возвращает нормализованную team', async () => {
-		mockPost.mockResolvedValue(
-			axiosResponse({
-				id: 'team-1',
-				name: 'Dream Team',
-				description: null,
-				avatarUrl: null,
-				createdAt: '2024-01-01',
-				updatedAt: '2024-01-02',
-				members: [
-					{
-						user: {
-							id: 'user-1',
-							name: 'Alex',
-							email: 'alex@test.com',
-						},
-						role: 'OWNER',
-					},
-				],
-			}),
+		mockApiClient.post.mockResolvedValue(
+			axiosResponse(
+				createTeamApiFixture({
+					name: 'Dream Team',
+					updatedAt: '2024-01-02',
+					members: [
+						createNestedTeamMemberApiFixture({ role: 'OWNER', joinedAt: undefined }),
+					],
+				}),
+			),
 		)
 
 		const result = await teamInvitationsService.acceptInvitation('token-1')
 
-		expect(mockPost).toHaveBeenCalledWith('/invitations/token-1/accept')
+		expect(mockApiClient.post).toHaveBeenCalledWith('/invitations/token-1/accept')
 		expect(result.members[0]).toEqual({
-			id: 'user-1',
+			id: 'member-1',
 			userId: 'user-1',
 			name: 'Alex',
 			email: 'alex@test.com',
@@ -155,35 +91,36 @@ describe('teamInvitationsService', () => {
 		})
 	})
 
+	it('declineInvitation вызывает decline endpoint и возвращает invitation', async () => {
+		mockApiClient.post.mockResolvedValue(
+			axiosResponse(
+				createTeamInvitationApiFixture({
+					status: 'DECLINED',
+					updatedAt: '2026-04-09T12:05:00.000Z',
+				}),
+			),
+		)
+
+		const result = await teamInvitationsService.declineInvitation('token-1')
+
+		expect(mockApiClient.post).toHaveBeenCalledWith('/invitations/token-1/decline')
+		expect(result.status).toBe('DECLINED')
+		expect(result.team.name).toBe('Dream Team')
+	})
+
 	it('revokeInvitation вызывает delete endpoint и возвращает invitation', async () => {
-		mockDelete.mockResolvedValue(
-			axiosResponse({
-				id: 'inv-1',
-				teamId: 'team-1',
-				invitedById: 'user-1',
-				email: 'new@test.com',
-				role: 'MEMBER',
-				status: 'DECLINED',
-				token: 'token-1',
-				expiresAt: '2026-04-11T12:00:00.000Z',
-				createdAt: '2026-04-09T12:00:00.000Z',
-				updatedAt: '2026-04-09T12:05:00.000Z',
-				team: {
-					id: 'team-1',
-					name: 'Dream Team',
-					avatarUrl: null,
-				},
-				invitedBy: {
-					id: 'user-1',
-					name: 'Alex',
-					email: 'alex@test.com',
-				},
-			}),
+		mockApiClient.delete.mockResolvedValue(
+			axiosResponse(
+				createTeamInvitationApiFixture({
+					status: 'DECLINED',
+					updatedAt: '2026-04-09T12:05:00.000Z',
+				}),
+			),
 		)
 
 		const result = await teamInvitationsService.revokeInvitation('team-1', 'inv-1')
 
-		expect(mockDelete).toHaveBeenCalledWith('/teams/team-1/invitations/inv-1')
+		expect(mockApiClient.delete).toHaveBeenCalledWith('/teams/team-1/invitations/inv-1')
 		expect(result.status).toBe('DECLINED')
 	})
 })

--- a/apps/web/test/unit/shared/lib/api/team-invitations-service.spec.ts
+++ b/apps/web/test/unit/shared/lib/api/team-invitations-service.spec.ts
@@ -1,0 +1,189 @@
+import { AxiosHeaders, type AxiosResponse } from 'axios'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { teamInvitationsService } from '@/shared/lib/api/team-invitations-service'
+
+const { mockGet, mockPost, mockDelete } = vi.hoisted(() => ({
+	mockGet: vi.fn(),
+	mockPost: vi.fn(),
+	mockDelete: vi.fn(),
+}))
+
+vi.mock('@/shared/lib/api/client', () => ({
+	client: {
+		get: mockGet,
+		post: mockPost,
+		delete: mockDelete,
+	},
+}))
+
+function axiosResponse<T>(data: T): AxiosResponse<T> {
+	return {
+		data,
+		status: 200,
+		statusText: 'OK',
+		headers: {},
+		config: { headers: new AxiosHeaders() },
+	}
+}
+
+describe('teamInvitationsService', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('sendInvitation отправляет запрос и нормализует invitation response', async () => {
+		mockPost.mockResolvedValue(
+			axiosResponse({
+				id: 'inv-1',
+				teamId: 'team-1',
+				invitedById: 'user-1',
+				email: 'new@test.com',
+				role: 'ADMIN',
+				status: 'PENDING',
+				token: 'token-1',
+				expiresAt: '2026-04-11T12:00:00.000Z',
+				createdAt: '2026-04-09T12:00:00.000Z',
+				updatedAt: '2026-04-09T12:00:00.000Z',
+				team: {
+					id: 'team-1',
+					name: 'Dream Team',
+					avatarUrl: null,
+				},
+				invitedBy: {
+					id: 'user-1',
+					name: 'Alex',
+					email: 'alex@test.com',
+				},
+			}),
+		)
+
+		const result = await teamInvitationsService.sendInvitation('team-1', {
+			email: 'new@test.com',
+			role: 'ADMIN',
+		})
+
+		expect(mockPost).toHaveBeenCalledWith('/teams/team-1/invitations', {
+			email: 'new@test.com',
+			role: 'ADMIN',
+		})
+		expect(result.team.name).toBe('Dream Team')
+		expect(result.invitedBy.email).toBe('alex@test.com')
+	})
+
+	it('getMyInvitations нормализует список входящих invitations', async () => {
+		mockGet.mockResolvedValue(
+			axiosResponse([
+				{
+					id: 'inv-1',
+					email: 'new@test.com',
+					role: 'MEMBER',
+					token: 'token-1',
+					expiresAt: '2026-04-11T12:00:00.000Z',
+					createdAt: '2026-04-09T12:00:00.000Z',
+					team: {
+						id: 'team-1',
+						name: 'Dream Team',
+						avatarUrl: null,
+					},
+					invitedBy: {
+						id: 'user-1',
+						name: 'Alex',
+						email: 'alex@test.com',
+					},
+				},
+			]),
+		)
+
+		const result = await teamInvitationsService.getMyInvitations()
+
+		expect(mockGet).toHaveBeenCalledWith('/invitations/me')
+		expect(result).toEqual([
+			{
+				id: 'inv-1',
+				email: 'new@test.com',
+				role: 'MEMBER',
+				token: 'token-1',
+				expiresAt: '2026-04-11T12:00:00.000Z',
+				createdAt: '2026-04-09T12:00:00.000Z',
+				team: {
+					id: 'team-1',
+					name: 'Dream Team',
+					avatarUrl: null,
+				},
+				invitedBy: {
+					id: 'user-1',
+					name: 'Alex',
+					email: 'alex@test.com',
+				},
+			},
+		])
+	})
+
+	it('acceptInvitation возвращает нормализованную team', async () => {
+		mockPost.mockResolvedValue(
+			axiosResponse({
+				id: 'team-1',
+				name: 'Dream Team',
+				description: null,
+				avatarUrl: null,
+				createdAt: '2024-01-01',
+				updatedAt: '2024-01-02',
+				members: [
+					{
+						user: {
+							id: 'user-1',
+							name: 'Alex',
+							email: 'alex@test.com',
+						},
+						role: 'OWNER',
+					},
+				],
+			}),
+		)
+
+		const result = await teamInvitationsService.acceptInvitation('token-1')
+
+		expect(mockPost).toHaveBeenCalledWith('/invitations/token-1/accept')
+		expect(result.members[0]).toEqual({
+			id: 'user-1',
+			userId: 'user-1',
+			name: 'Alex',
+			email: 'alex@test.com',
+			role: 'OWNER',
+			joinedAt: '',
+		})
+	})
+
+	it('revokeInvitation вызывает delete endpoint и возвращает invitation', async () => {
+		mockDelete.mockResolvedValue(
+			axiosResponse({
+				id: 'inv-1',
+				teamId: 'team-1',
+				invitedById: 'user-1',
+				email: 'new@test.com',
+				role: 'MEMBER',
+				status: 'DECLINED',
+				token: 'token-1',
+				expiresAt: '2026-04-11T12:00:00.000Z',
+				createdAt: '2026-04-09T12:00:00.000Z',
+				updatedAt: '2026-04-09T12:05:00.000Z',
+				team: {
+					id: 'team-1',
+					name: 'Dream Team',
+					avatarUrl: null,
+				},
+				invitedBy: {
+					id: 'user-1',
+					name: 'Alex',
+					email: 'alex@test.com',
+				},
+			}),
+		)
+
+		const result = await teamInvitationsService.revokeInvitation('team-1', 'inv-1')
+
+		expect(mockDelete).toHaveBeenCalledWith('/teams/team-1/invitations/inv-1')
+		expect(result.status).toBe('DECLINED')
+	})
+})

--- a/apps/web/test/unit/shared/lib/api/team-members-service.spec.ts
+++ b/apps/web/test/unit/shared/lib/api/team-members-service.spec.ts
@@ -1,106 +1,84 @@
-import { AxiosHeaders, type AxiosResponse } from 'axios'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import '@/test/mocks/api/http-client.mock'
+
+import { mockApiClient, resetApiClientMock } from '@/test/mocks/api/http-client.mock'
+import {
+	axiosResponse,
+	createDeleteTeamResponseFixture,
+	createNestedTeamMemberApiFixture,
+	createTeamMemberFixture,
+} from '@/test/mocks/api/team-api.fixtures'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import { teamMembersService } from '@/shared/lib/api/team-members-service'
 
-const { mockGet, mockPatch, mockDelete } = vi.hoisted(() => ({
-	mockGet: vi.fn(),
-	mockPatch: vi.fn(),
-	mockDelete: vi.fn(),
-}))
-
-vi.mock('@/shared/lib/api/client', () => ({
-	client: {
-		get: mockGet,
-		patch: mockPatch,
-		delete: mockDelete,
-	},
-}))
-
-function axiosResponse<T>(data: T): AxiosResponse<T> {
-	return {
-		data,
-		status: 200,
-		statusText: 'OK',
-		headers: {},
-		config: { headers: new AxiosHeaders() },
-	}
-}
-
 describe('teamMembersService', () => {
 	beforeEach(() => {
-		vi.clearAllMocks()
+		resetApiClientMock()
 	})
 
 	it('getMembers нормализует nested user в плоский TeamMember', async () => {
-		mockGet.mockResolvedValue(
-			axiosResponse([
-				{
-					id: 'member-1',
-					teamId: 'team-1',
-					userId: 'user-1',
-					user: {
-						id: 'user-1',
-						name: 'Alex',
-						email: 'alex@test.com',
-					},
-					role: 'ADMIN',
-					joinedAt: '2024-02-01',
-				},
-			]),
+		mockApiClient.get.mockResolvedValue(
+			axiosResponse([createNestedTeamMemberApiFixture()]),
 		)
 
 		const result = await teamMembersService.getMembers('team-1')
 
-		expect(mockGet).toHaveBeenCalledWith('/teams/team-1/members')
+		expect(mockApiClient.get).toHaveBeenCalledWith('/teams/team-1/members')
 		expect(result).toEqual([
-			{
+			createTeamMemberFixture({
 				id: 'member-1',
 				userId: 'user-1',
 				name: 'Alex',
 				email: 'alex@test.com',
 				role: 'ADMIN',
 				joinedAt: '2024-02-01',
-			},
+			}),
 		])
 	})
 
 	it('changeRole вызывает правильный endpoint и возвращает member', async () => {
-		mockPatch.mockResolvedValue(
-			axiosResponse({
-				id: 'member-1',
-				userId: 'user-1',
-				name: 'Alex',
-				email: 'alex@test.com',
-				role: 'MEMBER',
-				joinedAt: '2024-02-01',
-			}),
+		mockApiClient.patch.mockResolvedValue(
+			axiosResponse(
+				createTeamMemberFixture({
+					id: 'member-1',
+					userId: 'user-1',
+					name: 'Alex',
+					email: 'alex@test.com',
+					role: 'MEMBER',
+					joinedAt: '2024-02-01',
+				}),
+			),
 		)
 
 		const result = await teamMembersService.changeRole('team-1', 'user-1', {
 			role: 'MEMBER',
 		})
 
-		expect(mockPatch).toHaveBeenCalledWith('/teams/team-1/members/user-1/role', {
-			role: 'MEMBER',
-		})
+		expect(mockApiClient.patch).toHaveBeenCalledWith(
+			'/teams/team-1/members/user-1/role',
+			{
+				role: 'MEMBER',
+			},
+		)
 		expect(result.role).toBe('MEMBER')
 	})
 
 	it('removeMember возвращает серверный ответ без изменений', async () => {
-		mockDelete.mockResolvedValue(
-			axiosResponse({
-				message: 'Участник успешно исключён',
-				success: true,
-			}),
+		mockApiClient.delete.mockResolvedValue(
+			axiosResponse(
+				createDeleteTeamResponseFixture({
+					message: 'Участник успешно исключён',
+				}),
+			),
 		)
 
 		const result = await teamMembersService.removeMember('team-1', 'user-1')
 
-		expect(mockDelete).toHaveBeenCalledWith('/teams/team-1/members/user-1')
-		expect(result).toEqual({
-			message: 'Участник успешно исключён',
-			success: true,
-		})
+		expect(mockApiClient.delete).toHaveBeenCalledWith('/teams/team-1/members/user-1')
+		expect(result).toEqual(
+			createDeleteTeamResponseFixture({
+				message: 'Участник успешно исключён',
+			}),
+		)
 	})
 })

--- a/apps/web/test/unit/shared/lib/api/team-members-service.spec.ts
+++ b/apps/web/test/unit/shared/lib/api/team-members-service.spec.ts
@@ -1,0 +1,106 @@
+import { AxiosHeaders, type AxiosResponse } from 'axios'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { teamMembersService } from '@/shared/lib/api/team-members-service'
+
+const { mockGet, mockPatch, mockDelete } = vi.hoisted(() => ({
+	mockGet: vi.fn(),
+	mockPatch: vi.fn(),
+	mockDelete: vi.fn(),
+}))
+
+vi.mock('@/shared/lib/api/client', () => ({
+	client: {
+		get: mockGet,
+		patch: mockPatch,
+		delete: mockDelete,
+	},
+}))
+
+function axiosResponse<T>(data: T): AxiosResponse<T> {
+	return {
+		data,
+		status: 200,
+		statusText: 'OK',
+		headers: {},
+		config: { headers: new AxiosHeaders() },
+	}
+}
+
+describe('teamMembersService', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('getMembers нормализует nested user в плоский TeamMember', async () => {
+		mockGet.mockResolvedValue(
+			axiosResponse([
+				{
+					id: 'member-1',
+					teamId: 'team-1',
+					userId: 'user-1',
+					user: {
+						id: 'user-1',
+						name: 'Alex',
+						email: 'alex@test.com',
+					},
+					role: 'ADMIN',
+					joinedAt: '2024-02-01',
+				},
+			]),
+		)
+
+		const result = await teamMembersService.getMembers('team-1')
+
+		expect(mockGet).toHaveBeenCalledWith('/teams/team-1/members')
+		expect(result).toEqual([
+			{
+				id: 'member-1',
+				userId: 'user-1',
+				name: 'Alex',
+				email: 'alex@test.com',
+				role: 'ADMIN',
+				joinedAt: '2024-02-01',
+			},
+		])
+	})
+
+	it('changeRole вызывает правильный endpoint и возвращает member', async () => {
+		mockPatch.mockResolvedValue(
+			axiosResponse({
+				id: 'member-1',
+				userId: 'user-1',
+				name: 'Alex',
+				email: 'alex@test.com',
+				role: 'MEMBER',
+				joinedAt: '2024-02-01',
+			}),
+		)
+
+		const result = await teamMembersService.changeRole('team-1', 'user-1', {
+			role: 'MEMBER',
+		})
+
+		expect(mockPatch).toHaveBeenCalledWith('/teams/team-1/members/user-1/role', {
+			role: 'MEMBER',
+		})
+		expect(result.role).toBe('MEMBER')
+	})
+
+	it('removeMember возвращает серверный ответ без изменений', async () => {
+		mockDelete.mockResolvedValue(
+			axiosResponse({
+				message: 'Участник успешно исключён',
+				success: true,
+			}),
+		)
+
+		const result = await teamMembersService.removeMember('team-1', 'user-1')
+
+		expect(mockDelete).toHaveBeenCalledWith('/teams/team-1/members/user-1')
+		expect(result).toEqual({
+			message: 'Участник успешно исключён',
+			success: true,
+		})
+	})
+})

--- a/apps/web/test/unit/shared/lib/api/teams-normalizers.spec.ts
+++ b/apps/web/test/unit/shared/lib/api/teams-normalizers.spec.ts
@@ -1,0 +1,198 @@
+import {
+	createMyInvitationApiFixture,
+	createNestedTeamMemberApiFixture,
+	createTeamApiFixture,
+	createTeamInvitationApiFixture,
+	createTeamMemberFixture,
+} from '@/test/mocks/api/team-api.fixtures'
+import { describe, expect, it } from 'vitest'
+
+import { TEAM_INVITATION_STATUSES, TEAM_ROLES } from '@repo/types'
+
+import {
+	normalizeMyInvitation,
+	normalizeTeam,
+	normalizeTeamInvitation,
+	normalizeTeamMember,
+} from '@/shared/lib/api/teams-normalizers'
+
+describe('teams-normalizers', () => {
+	describe('normalizeTeamMember', () => {
+		it('возвращает плоского участника без потерь', () => {
+			const member = createTeamMemberFixture({
+				id: 'member-1',
+				userId: 'user-1',
+				name: 'Alex',
+				email: 'alex@test.com',
+				role: TEAM_ROLES.MEMBER,
+				joinedAt: '2024-02-01',
+			})
+
+			expect(normalizeTeamMember(member)).toEqual(member)
+		})
+
+		it('маппит nested user и подставляет fallback для id и joinedAt', () => {
+			const member = createNestedTeamMemberApiFixture({
+				id: undefined,
+				userId: undefined,
+				joinedAt: undefined,
+				user: {
+					id: 'user-42',
+					name: 'Casey',
+					email: 'casey@test.com',
+				},
+			})
+
+			expect(normalizeTeamMember(member)).toEqual({
+				id: 'user-42',
+				userId: 'user-42',
+				name: 'Casey',
+				email: 'casey@test.com',
+				role: TEAM_ROLES.ADMIN,
+				joinedAt: '',
+			})
+		})
+	})
+
+	describe('normalizeTeam', () => {
+		it('нормализует mixed members list', () => {
+			const team = createTeamApiFixture({
+				members: [
+					createNestedTeamMemberApiFixture({
+						id: undefined,
+						userId: undefined,
+						joinedAt: undefined,
+					}),
+					createTeamMemberFixture({
+						id: 'member-2',
+						userId: 'user-2',
+						name: 'Jamie',
+						email: 'jamie@test.com',
+						role: TEAM_ROLES.MEMBER,
+						joinedAt: '2024-03-01',
+					}),
+				],
+			})
+
+			expect(normalizeTeam(team).members).toEqual([
+				{
+					id: 'user-1',
+					userId: 'user-1',
+					name: 'Alex',
+					email: 'alex@test.com',
+					role: TEAM_ROLES.ADMIN,
+					joinedAt: '',
+				},
+				{
+					id: 'member-2',
+					userId: 'user-2',
+					name: 'Jamie',
+					email: 'jamie@test.com',
+					role: TEAM_ROLES.MEMBER,
+					joinedAt: '2024-03-01',
+				},
+			])
+		})
+	})
+
+	describe('normalizeTeamInvitation', () => {
+		it('сохраняет валидный invitation response', () => {
+			const invitation = createTeamInvitationApiFixture({
+				role: TEAM_ROLES.ADMIN,
+				status: TEAM_INVITATION_STATUSES.PENDING,
+			})
+
+			expect(normalizeTeamInvitation(invitation)).toEqual({
+				...invitation,
+				invitedBy: {
+					id: 'user-1',
+					name: 'Alex',
+					email: 'alex@test.com',
+				},
+				team: {
+					id: 'team-1',
+					name: 'Dream Team',
+					avatarUrl: null,
+				},
+			})
+		})
+
+		it('подставляет дефолты для пустого invitation response', () => {
+			expect(
+				normalizeTeamInvitation({
+					invitedBy: null,
+					team: null,
+				}),
+			).toEqual({
+				id: '',
+				teamId: '',
+				invitedById: '',
+				email: '',
+				role: TEAM_ROLES.MEMBER,
+				status: TEAM_INVITATION_STATUSES.PENDING,
+				token: '',
+				expiresAt: '',
+				createdAt: '',
+				updatedAt: '',
+				invitedBy: {
+					id: '',
+					name: null,
+					email: '',
+				},
+				team: {
+					id: '',
+					name: '',
+					avatarUrl: null,
+				},
+			})
+		})
+	})
+
+	describe('normalizeMyInvitation', () => {
+		it('сохраняет валидный my invitation response', () => {
+			const invitation = createMyInvitationApiFixture({
+				role: TEAM_ROLES.ADMIN,
+			})
+
+			expect(normalizeMyInvitation(invitation)).toEqual({
+				...invitation,
+				invitedBy: {
+					id: 'user-1',
+					name: 'Alex',
+					email: 'alex@test.com',
+				},
+				team: {
+					id: 'team-1',
+					name: 'Dream Team',
+					avatarUrl: null,
+				},
+			})
+		})
+
+		it('подставляет дефолты для пустого my invitation response', () => {
+			expect(
+				normalizeMyInvitation({
+					invitedBy: null,
+					team: null,
+				}),
+			).toEqual({
+				id: '',
+				email: '',
+				role: TEAM_ROLES.MEMBER,
+				token: '',
+				expiresAt: '',
+				createdAt: '',
+				team: {
+					id: '',
+					name: '',
+					avatarUrl: null,
+				},
+				invitedBy: {
+					id: '',
+					name: null,
+					email: '',
+				},
+			})
+		})
+	})
+})

--- a/apps/web/test/unit/shared/lib/api/teams-service.spec.ts
+++ b/apps/web/test/unit/shared/lib/api/teams-service.spec.ts
@@ -1,120 +1,178 @@
-import { AxiosHeaders, type AxiosResponse } from 'axios'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import '@/test/mocks/api/http-client.mock'
+
+import { mockApiClient, resetApiClientMock } from '@/test/mocks/api/http-client.mock'
+import {
+	axiosResponse,
+	createDeleteTeamResponseFixture,
+	createNestedTeamMemberApiFixture,
+	createTeamApiFixture,
+	createTeamListItemFixture,
+	createTeamMemberFixture,
+} from '@/test/mocks/api/team-api.fixtures'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import { teamsService } from '@/shared/lib/api/teams-service'
 
-const { mockGet, mockPost, mockPatch, mockDelete } = vi.hoisted(() => ({
-	mockGet: vi.fn(),
-	mockPost: vi.fn(),
-	mockPatch: vi.fn(),
-	mockDelete: vi.fn(),
-}))
-
-vi.mock('@/shared/lib/api/client', () => ({
-	client: {
-		get: mockGet,
-		post: mockPost,
-		patch: mockPatch,
-		delete: mockDelete,
-	},
-}))
-
-function axiosResponse<T>(data: T): AxiosResponse<T> {
-	return {
-		data,
-		status: 200,
-		statusText: 'OK',
-		headers: {},
-		config: { headers: new AxiosHeaders() },
-	}
-}
-
-const baseTeam = {
-	id: 'team-1',
-	name: 'Team',
-	description: null,
-	avatarUrl: null,
-	createdAt: '2024-01-01',
-	updatedAt: '2024-01-01',
-}
-
-describe('teamsService members normalization', () => {
+describe('teamsService', () => {
 	beforeEach(() => {
-		vi.clearAllMocks()
+		resetApiClientMock()
 	})
 
-	it('данные приходят как { user, role } и маппятся в плоский member', async () => {
-		mockGet.mockResolvedValue(
-			axiosResponse({
-				...baseTeam,
-				members: [
-					{
-						user: {
-							id: 'user-1',
-							name: 'Alex',
-							email: 'alex@test.com',
-						},
-						role: 'ADMIN',
-					},
-				],
+	it('getAll возвращает список команд без дополнительных преобразований', async () => {
+		mockApiClient.get.mockResolvedValue(
+			axiosResponse([
+				createTeamListItemFixture({
+					name: 'Team',
+					currentUserRole: 'OWNER',
+				}),
+			]),
+		)
+
+		const result = await teamsService.getAll()
+
+		expect(mockApiClient.get).toHaveBeenCalledWith('/teams')
+		expect(result).toEqual([
+			createTeamListItemFixture({
+				name: 'Team',
+				currentUserRole: 'OWNER',
 			}),
+		])
+	})
+
+	it('getById маппит nested members в плоский формат', async () => {
+		mockApiClient.get.mockResolvedValue(
+			axiosResponse(
+				createTeamApiFixture({
+					name: 'Team',
+					members: [createNestedTeamMemberApiFixture({ joinedAt: undefined })],
+				}),
+			),
 		)
 
 		const result = await teamsService.getById('team-1')
 
 		expect(result.members).toEqual([
-			{
-				id: 'user-1',
+			createTeamMemberFixture({
+				id: 'member-1',
 				userId: 'user-1',
 				name: 'Alex',
 				email: 'alex@test.com',
 				role: 'ADMIN',
 				joinedAt: '',
-			},
+			}),
 		])
 	})
 
-	it('данные уже плоские и маппятся без потерь', async () => {
-		mockGet.mockResolvedValue(
-			axiosResponse({
-				...baseTeam,
-				members: [
-					{
-						id: 'member-1',
-						userId: 'user-1',
-						name: 'Alex',
-						email: 'alex@test.com',
-						role: 'MEMBER',
-						joinedAt: '2024-02-01',
-					},
-				],
-			}),
+	it('getById сохраняет уже плоских участников без потерь', async () => {
+		mockApiClient.get.mockResolvedValue(
+			axiosResponse(
+				createTeamApiFixture({
+					name: 'Team',
+					members: [
+						createTeamMemberFixture({
+							id: 'member-1',
+							userId: 'user-1',
+							name: 'Alex',
+							email: 'alex@test.com',
+							role: 'MEMBER',
+							joinedAt: '2024-02-01',
+						}),
+					],
+				}),
+			),
 		)
 
 		const result = await teamsService.getById('team-1')
 
+		expect(mockApiClient.get).toHaveBeenCalledWith('/teams/team-1')
 		expect(result.members).toEqual([
-			{
+			createTeamMemberFixture({
 				id: 'member-1',
 				userId: 'user-1',
 				name: 'Alex',
 				email: 'alex@test.com',
 				role: 'MEMBER',
 				joinedAt: '2024-02-01',
-			},
+			}),
 		])
 	})
 
-	it('пустой массив members возвращается как пустой массив', async () => {
-		mockGet.mockResolvedValue(
-			axiosResponse({
-				...baseTeam,
-				members: [],
-			}),
+	it('getById возвращает пустой массив участников как есть', async () => {
+		mockApiClient.get.mockResolvedValue(
+			axiosResponse(
+				createTeamApiFixture({
+					name: 'Team',
+					members: [],
+				}),
+			),
 		)
 
 		const result = await teamsService.getById('team-1')
 
 		expect(result.members).toEqual([])
+	})
+
+	it('create отправляет запрос на создание и нормализует ответ', async () => {
+		mockApiClient.post.mockResolvedValue(
+			axiosResponse(
+				createTeamApiFixture({
+					name: 'Team',
+					members: [
+						createNestedTeamMemberApiFixture({ role: 'OWNER', joinedAt: undefined }),
+					],
+				}),
+			),
+		)
+
+		const result = await teamsService.create({
+			name: 'Dream Team',
+		})
+
+		expect(mockApiClient.post).toHaveBeenCalledWith('/teams/new', {
+			name: 'Dream Team',
+		})
+		expect(result.members[0]).toEqual({
+			id: 'member-1',
+			userId: 'user-1',
+			name: 'Alex',
+			email: 'alex@test.com',
+			role: 'OWNER',
+			joinedAt: '',
+		})
+	})
+
+	it('update вызывает endpoint команды и нормализует ответ', async () => {
+		mockApiClient.patch.mockResolvedValue(
+			axiosResponse(
+				createTeamApiFixture({
+					name: 'Updated Team',
+					description: 'Refined description',
+					members: [],
+				}),
+			),
+		)
+
+		const result = await teamsService.update('team-1', {
+			name: 'Updated Team',
+			description: 'Refined description',
+		})
+
+		expect(mockApiClient.patch).toHaveBeenCalledWith('/teams/team-1', {
+			name: 'Updated Team',
+			description: 'Refined description',
+		})
+		expect(result.name).toBe('Updated Team')
+		expect(result.members).toEqual([])
+	})
+
+	it('delete возвращает серверный ответ без изменений', async () => {
+		mockApiClient.delete.mockResolvedValue(
+			axiosResponse(createDeleteTeamResponseFixture()),
+		)
+
+		const result = await teamsService.delete('team-1')
+
+		expect(mockApiClient.delete).toHaveBeenCalledWith('/teams/team-1')
+		expect(result).toEqual(createDeleteTeamResponseFixture())
 	})
 })

--- a/apps/web/test/unit/views/teams/team-card.spec.tsx
+++ b/apps/web/test/unit/views/teams/team-card.spec.tsx
@@ -1,16 +1,24 @@
 import { createTeamCardModel, createTeamMember } from '@/test/mocks/team-card.fixtures'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import '@/test/mocks/team-card-ui.mock'
 
+import type { TeamCardModel } from '@/views/teams/model/types'
 import { TeamCard } from '@/views/teams/ui/team-card'
 
 describe('TeamCard', () => {
-	let onOpen: ReturnType<typeof vi.fn>
+	let onOpen: (team: TeamCardModel) => void
+	let lastOpenedTeam: TeamCardModel | null
+	let openCallCount: number
 
 	beforeEach(() => {
-		onOpen = vi.fn()
+		lastOpenedTeam = null
+		openCallCount = 0
+		onOpen = (team) => {
+			lastOpenedTeam = team
+			openCallCount += 1
+		}
 	})
 
 	afterEach(cleanup)
@@ -39,8 +47,8 @@ describe('TeamCard', () => {
 		render(<TeamCard team={team} onOpen={onOpen} />)
 		fireEvent.click(screen.getByRole('button'))
 
-		expect(onOpen).toHaveBeenCalledOnce()
-		expect(onOpen).toHaveBeenCalledWith(
+		expect(openCallCount).toBe(1)
+		expect(lastOpenedTeam).toEqual(
 			expect.objectContaining({ id: '1', name: 'Dream Team' }),
 		)
 	})

--- a/packages/types/src/teams/constants/team-invitation-status.constants.ts
+++ b/packages/types/src/teams/constants/team-invitation-status.constants.ts
@@ -1,0 +1,9 @@
+export const TEAM_INVITATION_STATUSES = {
+	PENDING: 'PENDING',
+	ACCEPTED: 'ACCEPTED',
+	DECLINED: 'DECLINED',
+	EXPIRED: 'EXPIRED',
+} as const
+
+export type TeamInvitationStatus =
+	(typeof TEAM_INVITATION_STATUSES)[keyof typeof TEAM_INVITATION_STATUSES]

--- a/packages/types/src/teams/index.ts
+++ b/packages/types/src/teams/index.ts
@@ -1,4 +1,5 @@
 export * from './constants/team-role.constants'
+export * from './constants/team-invitation-status.constants'
 export * from './schemas/create-team.schema'
 export * from './schemas/update-team.schema'
 export * from './schemas/change-role.schema'

--- a/packages/types/src/teams/types/team.types.ts
+++ b/packages/types/src/teams/types/team.types.ts
@@ -1,4 +1,5 @@
 import type { TeamRole } from '../constants/team-role.constants'
+import type { TeamInvitationStatus } from '../constants/team-invitation-status.constants'
 
 export interface TeamMember {
 	id: string
@@ -33,4 +34,42 @@ export interface TeamListItem {
 export interface DeleteTeamResponse {
 	message: string
 	success: boolean
+}
+
+export interface InvitationInvitedBy {
+	id: string
+	name: string | null
+	email: string
+}
+
+export interface InvitationTeamSummary {
+	id: string
+	name: string
+	avatarUrl: string | null
+}
+
+export interface TeamInvitation {
+	id: string
+	teamId: string
+	invitedById: string
+	email: string
+	role: TeamRole
+	status: TeamInvitationStatus
+	token: string
+	expiresAt: string
+	createdAt: string
+	updatedAt: string
+	invitedBy: InvitationInvitedBy
+	team: InvitationTeamSummary
+}
+
+export interface MyInvitation {
+	id: string
+	email: string
+	role: TeamRole
+	token: string
+	expiresAt: string
+	createdAt: string
+	team: InvitationTeamSummary
+	invitedBy: InvitationInvitedBy
 }


### PR DESCRIPTION
Добавлена поддержка:

получения списка команд и деталей команды
создания, обновления и удаления команды
получения участников команды, смены роли и удаления участника
отправки, получения, принятия, отклонения и отзыва приглашений в команду
Также приведён в порядок тестовый слой для teams: вынесены моки, добавлены unit-тесты для сервисов, хуков, key factories и normalizers.