### PR TITLE
feat/refactor(api): Guard и декоратор для проверки ролей в команде (#122)

### DIFF
--- a/apps/api/src/teams/members/team-members.controller.ts
+++ b/apps/api/src/teams/members/team-members.controller.ts
@@ -8,6 +8,7 @@ import {
 	Param,
 	Patch,
 	Query,
+	UseGuards,
 } from '@nestjs/common'
 import {
 	ApiBearerAuth,
@@ -23,7 +24,9 @@ import { ChangeRoleDto } from './dto/change-role.dto'
 import { MemberResponse } from './dto/member-response.dto'
 import { Authorization } from '../../auth/decorators/authorization.decorator'
 import { Authorized } from '../../auth/decorators/authorized.decorator'
+import { Roles } from '../../auth/decorators/roles.decorator'
 import { PaginationQueryDto } from '../../common/dto/pagination-query.dto'
+import { RolesGuard } from '../../guards/roles.guard'
 import { ApiPaginatedOkResponse } from '../../utils/swagger.util'
 
 @ApiTags('Team Members')
@@ -54,6 +57,8 @@ export class TeamMembersController {
 	@ApiNotFoundResponse({ description: 'Команда или участник не найден' })
 	@Patch(':userId/role')
 	@HttpCode(HttpStatus.OK)
+	@UseGuards(RolesGuard)
+	@Roles('OWNER', 'ADMIN')
 	changeRole(
 		@Param('id') teamId: string,
 		@Param('userId') targetUserId: string,

--- a/apps/api/src/teams/members/team-members.module.ts
+++ b/apps/api/src/teams/members/team-members.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common'
+import { RolesGuard } from '../../guards/roles.guard'
 import { TeamMembersController } from './team-members.controller'
 import { TeamMembersService } from './team-members.service'
 
 @Module({
 	controllers: [TeamMembersController],
-	providers: [TeamMembersService],
+	providers: [TeamMembersService, RolesGuard],
 })
 export class TeamMembersModule {}

--- a/apps/api/src/teams/members/team-members.service.ts
+++ b/apps/api/src/teams/members/team-members.service.ts
@@ -1,18 +1,11 @@
 import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common'
 import { PrismaService } from '../../../prisma/prisma.service'
 import { ChangeRoleDto } from './dto/change-role.dto'
-import { TeamRole } from '@repo/types'
 import {
 	buildPaginatedResponse,
 	getPaginationPrismaParams,
 	type PaginationOptions,
 } from '../../utils/pagination.util'
-
-const ROLE_WEIGHT: Record<TeamRole, number> = {
-	OWNER: 3,
-	ADMIN: 2,
-	MEMBER: 1,
-}
 
 @Injectable()
 export class TeamMembersService {
@@ -64,18 +57,11 @@ export class TeamMembersService {
 			throw new ForbiddenException('Нельзя изменить свою собственную роль')
 		}
 
-		const [actor, target] = await Promise.all([
-			this.prisma.teamMember.findUnique({
-				where: { teamId_userId: { teamId, userId: actorId } },
-			}),
-			this.prisma.teamMember.findUnique({
-				where: { teamId_userId: { teamId, userId: targetUserId } },
-			}),
-		])
+		void actorId
 
-		if (!actor) {
-			throw new ForbiddenException('Вы не являетесь участником этой команды')
-		}
+		const target = await this.prisma.teamMember.findUnique({
+			where: { teamId_userId: { teamId, userId: targetUserId } },
+		})
 
 		if (!target) {
 			throw new NotFoundException('Участник не найден в команде')
@@ -84,20 +70,6 @@ export class TeamMembersService {
 		// OWNER не может быть понижен
 		if (target.role === 'OWNER') {
 			throw new ForbiddenException('Нельзя изменить роль владельца команды')
-		}
-
-		// ADMIN не может назначить роль выше своей (т.е. не может дать OWNER)
-		if (ROLE_WEIGHT[actor.role] <= ROLE_WEIGHT[dto.role as TeamRole]) {
-			// actor.role = MEMBER: не может назначать вообще
-			// actor.role = ADMIN: не может назначить OWNER (но OWNER в dto недоступен — схема запрещает)
-			if (actor.role !== 'OWNER' && actor.role !== 'ADMIN') {
-				throw new ForbiddenException('Недостаточно прав для изменения ролей')
-			}
-		}
-
-		// только OWNER или ADMIN могут менять роли
-		if (actor.role !== 'OWNER' && actor.role !== 'ADMIN') {
-			throw new ForbiddenException('Недостаточно прав для изменения ролей')
 		}
 
 		return this.prisma.teamMember.update({

--- a/apps/api/src/teams/teams.controller.ts
+++ b/apps/api/src/teams/teams.controller.ts
@@ -9,6 +9,7 @@ import {
 	Patch,
 	Post,
 	Query,
+	UseGuards,
 } from '@nestjs/common'
 import {
 	ApiBearerAuth,
@@ -27,7 +28,9 @@ import { UpdateTeamDto } from './dto/update-team.dto'
 import { TeamResponse, TeamListItemResponse } from './dto/team-response.dto'
 import { Authorization } from '../auth/decorators/authorization.decorator'
 import { Authorized } from '../auth/decorators/authorized.decorator'
+import { Roles } from '../auth/decorators/roles.decorator'
 import { PaginationQueryDto } from '../common/dto/pagination-query.dto'
+import { RolesGuard } from '../guards/roles.guard'
 import { ApiPaginatedOkResponse } from '../utils/swagger.util'
 
 @ApiTags('Teams')
@@ -71,6 +74,8 @@ export class TeamsController {
 	@ApiForbiddenResponse({ description: 'Недостаточно прав для обновления команды' })
 	@ApiNotFoundResponse({ description: 'Команда не найдена' })
 	@Patch(':id')
+	@UseGuards(RolesGuard)
+	@Roles('OWNER', 'ADMIN')
 	updateTeam(
 		@Param('id') teamId: string,
 		@Authorized('id') userId: string,
@@ -87,6 +92,8 @@ export class TeamsController {
 	@ApiForbiddenResponse({ description: 'Только владелец может удалить команду' })
 	@ApiNotFoundResponse({ description: 'Команда не найдена' })
 	@Delete(':id')
+	@UseGuards(RolesGuard)
+	@Roles('OWNER')
 	deleteTeam(@Param('id') teamId: string, @Authorized('id') userId: string) {
 		return this.teamsService.deleteTeam(teamId, userId)
 	}

--- a/apps/api/src/teams/teams.module.ts
+++ b/apps/api/src/teams/teams.module.ts
@@ -3,10 +3,11 @@ import { TeamsService } from './teams.service'
 import { TeamsController } from './teams.controller'
 import { TeamInvitationsModule } from './invitations/team-invitations.module'
 import { TeamMembersModule } from './members/team-members.module'
+import { RolesGuard } from '../guards/roles.guard'
 
 @Module({
 	imports: [TeamMembersModule, TeamInvitationsModule],
 	controllers: [TeamsController],
-	providers: [TeamsService],
+	providers: [TeamsService, RolesGuard],
 })
 export class TeamsModule {}

--- a/apps/api/src/teams/teams.service.ts
+++ b/apps/api/src/teams/teams.service.ts
@@ -99,13 +99,7 @@ export class TeamsService {
 	}
 
 	async updateTeam(teamId: string, userId: string, dto: UpdateTeamDto) {
-		const member = await this.prisma.teamMember.findUnique({
-			where: { teamId_userId: { teamId, userId } },
-		})
-
-		if (!member || (member.role !== 'OWNER' && member.role !== 'ADMIN')) {
-			throw new ForbiddenException('Недостаточно прав для обновления команды')
-		}
+		void userId
 
 		return this.prisma.team.update({
 			where: { id: teamId },
@@ -127,13 +121,7 @@ export class TeamsService {
 	}
 
 	async deleteTeam(teamId: string, userId: string) {
-		const member = await this.prisma.teamMember.findUnique({
-			where: { teamId_userId: { teamId, userId } },
-		})
-
-		if (!member || member.role !== 'OWNER') {
-			throw new ForbiddenException('Только владелец может удалить команду')
-		}
+		void userId
 
 		await this.prisma.team.delete({ where: { id: teamId } })
 

--- a/apps/api/test/unit/teams/team-members.service.spec.ts
+++ b/apps/api/test/unit/teams/team-members.service.spec.ts
@@ -104,43 +104,22 @@ describe('TeamMembersService', () => {
 
 	// ── changeRole ────────────────────────────────────────────────────────────
 	describe('changeRole', () => {
-		it('OWNER успешно меняет роль MEMBER', async () => {
+		it('успешно меняет роль участника (права проверяются в RolesGuard)', async () => {
 			const updated = {
 				...MEMBER_PLAIN,
 				role: 'ADMIN' as const,
 				user: { id: MEMBER_PLAIN.userId, name: 'Charlie', email: 'charlie@example.com' },
 			}
-			prisma.teamMember.findUnique
-				.mockResolvedValueOnce(MEMBER_OWNER) // actor
-				.mockResolvedValueOnce(MEMBER_PLAIN) // target
+			prisma.teamMember.findUnique.mockResolvedValueOnce(MEMBER_PLAIN) // target
 			prisma.teamMember.update.mockResolvedValue(updated)
 
 			const result = await service.changeRole(TEAM_ID, USER_ID, MEMBER_PLAIN.userId, {
 				role: 'ADMIN',
 			})
 
-			expect(prisma.teamMember.update).toHaveBeenCalledOnce()
-			expect(result).toEqual(updated)
-		})
-
-		it('ADMIN успешно меняет роль MEMBER', async () => {
-			const updated = {
-				...MEMBER_PLAIN,
-				role: 'ADMIN' as const,
-				user: { id: MEMBER_PLAIN.userId, name: 'Charlie', email: 'charlie@example.com' },
-			}
-			prisma.teamMember.findUnique
-				.mockResolvedValueOnce(MEMBER_ADMIN) // actor
-				.mockResolvedValueOnce(MEMBER_PLAIN) // target
-			prisma.teamMember.update.mockResolvedValue(updated)
-
-			const result = await service.changeRole(
-				TEAM_ID,
-				MEMBER_ADMIN.userId,
-				MEMBER_PLAIN.userId,
-				{ role: 'ADMIN' },
-			)
-
+			expect(prisma.teamMember.findUnique).toHaveBeenCalledWith({
+				where: { teamId_userId: { teamId: TEAM_ID, userId: MEMBER_PLAIN.userId } },
+			})
 			expect(prisma.teamMember.update).toHaveBeenCalledOnce()
 			expect(result).toEqual(updated)
 		})
@@ -152,31 +131,15 @@ describe('TeamMembersService', () => {
 		})
 
 		it('должен выбросить 403 если target является OWNER', async () => {
-			prisma.teamMember.findUnique
-				.mockResolvedValueOnce(MEMBER_ADMIN) // actor
-				.mockResolvedValueOnce(MEMBER_OWNER) // target is OWNER
+			prisma.teamMember.findUnique.mockResolvedValueOnce(MEMBER_OWNER)
 
 			await expect(
 				service.changeRole(TEAM_ID, MEMBER_ADMIN.userId, USER_ID, { role: 'MEMBER' }),
 			).rejects.toThrow(ForbiddenException)
 		})
 
-		it('должен выбросить 403 если MEMBER пытается менять роли', async () => {
-			prisma.teamMember.findUnique
-				.mockResolvedValueOnce(MEMBER_PLAIN) // actor is MEMBER
-				.mockResolvedValueOnce(MEMBER_ADMIN) // target
-
-			await expect(
-				service.changeRole(TEAM_ID, MEMBER_PLAIN.userId, MEMBER_ADMIN.userId, {
-					role: 'MEMBER',
-				}),
-			).rejects.toThrow(ForbiddenException)
-		})
-
 		it('должен выбросить 404 если target не в команде', async () => {
-			prisma.teamMember.findUnique
-				.mockResolvedValueOnce(MEMBER_OWNER) // actor
-				.mockResolvedValueOnce(null) // target not found
+			prisma.teamMember.findUnique.mockResolvedValueOnce(null)
 
 			await expect(
 				service.changeRole(TEAM_ID, USER_ID, 'unknown-id', { role: 'MEMBER' }),

--- a/apps/api/test/unit/teams/teams.service.spec.ts
+++ b/apps/api/test/unit/teams/teams.service.spec.ts
@@ -7,8 +7,6 @@ import {
 	USER_ID,
 	TEAM_ID,
 	TEAM,
-	MEMBER_OWNER,
-	MEMBER_ADMIN,
 	MEMBER_PLAIN,
 } from '../../helpers/teams.helpers'
 
@@ -174,50 +172,45 @@ describe('TeamsService', () => {
 
 	// ── updateTeam ────────────────────────────────────────────────────────────
 	describe('updateTeam', () => {
-		it('OWNER может обновить команду', async () => {
-			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+		it('обновляет команду (права проверяются в RolesGuard на уровне контроллера)', async () => {
 			const updated = { ...TEAM, name: 'New Name' }
 			prisma.team.update.mockResolvedValue(updated)
 
 			const result = await service.updateTeam(TEAM_ID, USER_ID, { name: 'New Name' })
 
 			expect(prisma.team.update).toHaveBeenCalledOnce()
+			expect(prisma.team.update).toHaveBeenCalledWith({
+				where: { id: TEAM_ID },
+				data: {
+					name: 'New Name',
+					description: undefined,
+					avatarUrl: undefined,
+				},
+				include: {
+					members: {
+						include: {
+							user: {
+								select: { id: true, name: true, email: true },
+							},
+						},
+					},
+				},
+			})
 			expect(result.name).toBe('New Name')
 		})
 
-		it('ADMIN может обновить команду', async () => {
-			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_ADMIN)
+		it('не проверяет роль внутри сервиса', async () => {
 			prisma.team.update.mockResolvedValue(TEAM)
 
 			await expect(
-				service.updateTeam(TEAM_ID, MEMBER_ADMIN.userId, { name: 'New Name' }),
+				service.updateTeam(TEAM_ID, 'any-user-id', { name: 'New Name' }),
 			).resolves.not.toThrow()
-		})
-
-		it('должен выбросить ForbiddenException если роль MEMBER', async () => {
-			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_PLAIN)
-
-			await expect(
-				service.updateTeam(TEAM_ID, MEMBER_PLAIN.userId, { name: 'New Name' }),
-			).rejects.toThrow(ForbiddenException)
-			await expect(
-				service.updateTeam(TEAM_ID, MEMBER_PLAIN.userId, { name: 'New Name' }),
-			).rejects.toThrow('Недостаточно прав для обновления команды')
-		})
-
-		it('должен выбросить ForbiddenException если пользователь не состоит в команде', async () => {
-			prisma.teamMember.findUnique.mockResolvedValue(null)
-
-			await expect(
-				service.updateTeam(TEAM_ID, 'stranger-id', { name: 'New Name' }),
-			).rejects.toThrow(ForbiddenException)
 		})
 	})
 
 	// ── deleteTeam ────────────────────────────────────────────────────────────
 	describe('deleteTeam', () => {
-		it('OWNER может удалить команду и получает подтверждение', async () => {
-			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+		it('удаляет команду и возвращает подтверждение (права проверяются в RolesGuard)', async () => {
 			prisma.team.delete.mockResolvedValue(TEAM)
 
 			const result = await service.deleteTeam(TEAM_ID, USER_ID)
@@ -226,31 +219,13 @@ describe('TeamsService', () => {
 			expect(result).toEqual({ message: 'Команда успешно удалена', success: true })
 		})
 
-		it('должен выбросить ForbiddenException если роль ADMIN', async () => {
-			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_ADMIN)
+		it('не проверяет роль внутри сервиса', async () => {
+			prisma.team.delete.mockResolvedValue(TEAM)
 
-			await expect(service.deleteTeam(TEAM_ID, MEMBER_ADMIN.userId)).rejects.toThrow(
-				ForbiddenException,
-			)
-			await expect(service.deleteTeam(TEAM_ID, MEMBER_ADMIN.userId)).rejects.toThrow(
-				'Только владелец может удалить команду',
-			)
-		})
-
-		it('должен выбросить ForbiddenException если роль MEMBER', async () => {
-			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_PLAIN)
-
-			await expect(service.deleteTeam(TEAM_ID, MEMBER_PLAIN.userId)).rejects.toThrow(
-				ForbiddenException,
-			)
-		})
-
-		it('должен выбросить ForbiddenException если пользователь не состоит в команде', async () => {
-			prisma.teamMember.findUnique.mockResolvedValue(null)
-
-			await expect(service.deleteTeam(TEAM_ID, 'stranger-id')).rejects.toThrow(
-				ForbiddenException,
-			)
+			await expect(service.deleteTeam(TEAM_ID, 'any-user-id')).resolves.toEqual({
+				message: 'Команда успешно удалена',
+				success: true,
+			})
 		})
 	})
 })

--- a/docs/backend/README.md
+++ b/docs/backend/README.md
@@ -62,7 +62,7 @@
   - `GET /invitations/me`
   - `POST /invitations/:token/accept`
   - `POST /invitations/:token/decline`
-- Team-scoped invitations routes защищены через `@Authorization()` + `@Roles('OWNER', 'ADMIN')` + `RolesGuard`
+- `PATCH /teams/:id`, `DELETE /teams/:id`, `PATCH /teams/:id/members/:userId/role` и все invitations routes защищены через `@Authorization()` + `@Roles(...)` + `RolesGuard` на уровне контроллера
 - Входящие invitations routes защищены через `@Authorization()`
 
 ### Планировщик задач

--- a/docs/backend/teams/README.md
+++ b/docs/backend/teams/README.md
@@ -51,8 +51,17 @@
 ## Роли и защита
 
 - Все team-scoped routes работают под `@Authorization()`
-- Routes управления invitations дополнительно защищены `@Roles('OWNER', 'ADMIN')` и `RolesGuard`
 - `RolesGuard` поддерживает маршруты с `params.teamId` и `params.id`
+- Следующие routes дополнительно защищены `@Roles(...)` и `RolesGuard` на уровне контроллера:
+
+| Route                                   | Требуемые роли   |
+| --------------------------------------- | ---------------- |
+| `PATCH /teams/:id`                      | `OWNER`, `ADMIN` |
+| `DELETE /teams/:id`                     | `OWNER`          |
+| `PATCH /teams/:id/members/:userId/role` | `OWNER`, `ADMIN` |
+| `POST /teams/:id/invitations`           | `OWNER`, `ADMIN` |
+| `GET /teams/:id/invitations`            | `OWNER`, `ADMIN` |
+| `DELETE /teams/:id/invitations/:invId`  | `OWNER`, `ADMIN` |
 
 ## Бизнес-правила invitations
 

--- a/docs/backend/test/unit-tests.md
+++ b/docs/backend/test/unit-tests.md
@@ -42,42 +42,38 @@ vi.mock('argon2', async () => await import('../../mocks/argon2'))
 Файл: `test/unit/teams/teams.service.spec.ts`
 Хелперы: `test/helpers/teams.helpers.ts` — `createPrismaMock`, `TEAM`, `TEAM_ID`, `USER_ID`, `MEMBER_OWNER/ADMIN/PLAIN`
 
-| Метод          | Сценарий                       | Ожидание                                    |
-| -------------- | ------------------------------ | ------------------------------------------- |
-| `createTeam`   | Создание команды               | Команда с участником OWNER                  |
-| `createTeam`   | С полями description/avatarUrl | Поля сохраняются                            |
-| `getUserTeams` | Пользователь в командах        | Список с `membersCount` и `currentUserRole` |
-| `getUserTeams` | Нет команд                     | Пустой массив                               |
-| `getTeamById`  | Пользователь — участник        | Объект команды                              |
-| `getTeamById`  | Команда не найдена             | `NotFoundException`                         |
-| `getTeamById`  | Пользователь не участник       | `ForbiddenException`                        |
-| `updateTeam`   | OWNER или ADMIN                | Обновлённая команда                         |
-| `updateTeam`   | MEMBER                         | `ForbiddenException`                        |
-| `updateTeam`   | Не в команде                   | `ForbiddenException`                        |
-| `deleteTeam`   | OWNER                          | Подтверждение удаления                      |
-| `deleteTeam`   | Не OWNER                       | `ForbiddenException`                        |
+| Метод          | Сценарий                                                                   | Ожидание                                    |
+| -------------- | -------------------------------------------------------------------------- | ------------------------------------------- |
+| `createTeam`   | Создание команды                                                           | Команда с участником OWNER                  |
+| `createTeam`   | С полями description/avatarUrl                                             | Поля сохраняются                            |
+| `getUserTeams` | Пользователь в командах                                                    | Список с `membersCount` и `currentUserRole` |
+| `getUserTeams` | Нет команд                                                                 | Пустой массив                               |
+| `getTeamById`  | Пользователь — участник                                                    | Объект команды                              |
+| `getTeamById`  | Команда не найдена                                                         | `NotFoundException`                         |
+| `getTeamById`  | Пользователь не участник                                                   | `ForbiddenException`                        |
+| `updateTeam`   | Обновление данных команды (доступ проверяется `RolesGuard` на контроллере) | Обновлённая команда                         |
+| `deleteTeam`   | Удаление команды (доступ проверяется `RolesGuard` на контроллере)          | Подтверждение удаления                      |
 
 ## TeamMembersService
 
 Файл: `test/unit/teams/team-members.service.spec.ts`
 Хелперы: те же из `test/helpers/teams.helpers.ts`
 
-| Метод          | Сценарий                         | Ожидание                                   |
-| -------------- | -------------------------------- | ------------------------------------------ |
-| `getMembers`   | Участник команды                 | Список участников                          |
-| `getMembers`   | Команда не найдена               | `NotFoundException`                        |
-| `getMembers`   | Не участник                      | `ForbiddenException`                       |
-| `changeRole`   | OWNER/ADMIN меняет роль MEMBER   | Обновлённый участник                       |
-| `changeRole`   | Самостоятельная смена своей роли | `ForbiddenException`                       |
-| `changeRole`   | Target — OWNER                   | `ForbiddenException`                       |
-| `changeRole`   | Actor — MEMBER                   | `ForbiddenException`                       |
-| `changeRole`   | Target не в команде              | `NotFoundException`                        |
-| `removeMember` | OWNER/ADMIN удаляет MEMBER       | `{ message: 'Участник успешно исключён' }` |
-| `removeMember` | Самовыход (self-leave)           | `{ message: 'Вы покинули команду' }`       |
-| `removeMember` | Попытка удалить OWNER            | `ForbiddenException`                       |
-| `removeMember` | MEMBER удаляет другого           | `ForbiddenException`                       |
-| `removeMember` | ADMIN удаляет другого ADMIN      | `ForbiddenException`                       |
-| `removeMember` | Target не в команде              | `NotFoundException`                        |
+| Метод          | Сценарий                                                                          | Ожидание                                   |
+| -------------- | --------------------------------------------------------------------------------- | ------------------------------------------ |
+| `getMembers`   | Участник команды                                                                  | Список участников                          |
+| `getMembers`   | Команда не найдена                                                                | `NotFoundException`                        |
+| `getMembers`   | Не участник                                                                       | `ForbiddenException`                       |
+| `changeRole`   | Смена роли участника (доступ OWNER/ADMIN проверяется `RolesGuard` на контроллере) | Обновлённый участник                       |
+| `changeRole`   | Самостоятельная смена своей роли                                                  | `ForbiddenException`                       |
+| `changeRole`   | Target — OWNER                                                                    | `ForbiddenException`                       |
+| `changeRole`   | Target не в команде                                                               | `NotFoundException`                        |
+| `removeMember` | OWNER/ADMIN удаляет MEMBER                                                        | `{ message: 'Участник успешно исключён' }` |
+| `removeMember` | Самовыход (self-leave)                                                            | `{ message: 'Вы покинули команду' }`       |
+| `removeMember` | Попытка удалить OWNER                                                             | `ForbiddenException`                       |
+| `removeMember` | MEMBER удаляет другого                                                            | `ForbiddenException`                       |
+| `removeMember` | ADMIN удаляет другого ADMIN                                                       | `ForbiddenException`                       |
+| `removeMember` | Target не в команде                                                               | `NotFoundException`                        |
 
 ## TeamInvitationsService
 


### PR DESCRIPTION
Что было реализовано:

- Упрощена и переведена проверка ролей на контроллер с помощь декораторов `@Role`.
- Удалена дублирующая проверка ролей в сервисах.
- Приведены тесты в порядок учитывая новую проверку ролей.
- Обновлена документация.