### PR TITLE
feat(api): добавить teamId к модели Project и создать миграцию (#237)

### DIFF
--- a/apps/api/prisma/migrations/20260503205712_add_team_id_to_project/migration.sql
+++ b/apps/api/prisma/migrations/20260503205712_add_team_id_to_project/migration.sql
@@ -1,0 +1,20 @@
+/*
+  Warnings:
+
+  - Added the required column `teamId` to the `Project` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Task" DROP CONSTRAINT "Task_projectId_fkey";
+
+-- AlterTable
+ALTER TABLE "Project" ADD COLUMN     "teamId" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "Project_teamId_idx" ON "Project"("teamId");
+
+-- AddForeignKey
+ALTER TABLE "Project" ADD CONSTRAINT "Project_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Task" ADD CONSTRAINT "Task_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -60,6 +60,7 @@ model Team {
   avatarUrl   String?
   members     TeamMember[]
   invitations TeamInvitation[]
+  projects    Project[]
   createdAt   DateTime         @default(now())
   updatedAt   DateTime         @updatedAt
 }
@@ -98,11 +99,15 @@ model Project {
   id          String   @id @default(uuid())
   name        String
   description String?
+  teamId      String
+  team        Team     @relation(fields: [teamId], references: [id], onDelete: Cascade)
   createdById String
   createdBy   User     @relation(fields: [createdById], references: [id])
   tasks       Task[]
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
+
+  @@index([teamId])
 }
 
 model Task {
@@ -112,7 +117,7 @@ model Task {
   status      TaskStatus @default(TODO)
   priority    Priority   @default(MEDIUM)
   projectId   String
-  project     Project    @relation(fields: [projectId], references: [id])
+  project     Project    @relation(fields: [projectId], references: [id], onDelete: Cascade)
   assigneeId  String?
   assignee    User?      @relation(fields: [assigneeId], references: [id])
   createdAt   DateTime   @default(now())

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -59,6 +59,38 @@ async function main() {
 
 	console.log(`✅ Создано пользователей: 3`)
 
+	// Создание тестовой команды
+	console.log('👥 Создание команды...')
+	const team = await prisma.team.create({
+		data: {
+			name: 'Команда разработки',
+			description: 'Основная команда разработчиков трекера задач',
+		},
+	})
+
+	// Добавление участников команды
+	await prisma.teamMember.createMany({
+		data: [
+			{
+				teamId: team.id,
+				userId: user1.id,
+				role: 'OWNER',
+			},
+			{
+				teamId: team.id,
+				userId: user2.id,
+				role: 'MEMBER',
+			},
+			{
+				teamId: team.id,
+				userId: user3.id,
+				role: 'ADMIN',
+			},
+		],
+	})
+
+	console.log(`✅ Создана команда "${team.name}" с 3 участниками`)
+
 	// Создание проектов
 	console.log('📁 Создание проектов...')
 	const project1 = await prisma.project.create({
@@ -67,6 +99,7 @@ async function main() {
 			description:
 				'Разработка системы управления задачами с использованием NestJS и Next.js',
 			createdById: user1.id,
+			teamId: team.id,
 		},
 	})
 
@@ -75,6 +108,7 @@ async function main() {
 			name: 'Мобильное приложение',
 			description: 'Разработка мобильного клиента для трекера задач',
 			createdById: user3.id,
+			teamId: team.id,
 		},
 	})
 
@@ -158,38 +192,6 @@ async function main() {
 	})
 
 	console.log(`✅ Создано задач: 8`)
-
-	// Создание тестовой команды
-	console.log('👥 Создание команды...')
-	const team = await prisma.team.create({
-		data: {
-			name: 'Команда разработки',
-			description: 'Основная команда разработчиков трекера задач',
-		},
-	})
-
-	// Добавление участников команды
-	await prisma.teamMember.createMany({
-		data: [
-			{
-				teamId: team.id,
-				userId: user1.id,
-				role: 'OWNER',
-			},
-			{
-				teamId: team.id,
-				userId: user2.id,
-				role: 'MEMBER',
-			},
-			{
-				teamId: team.id,
-				userId: user3.id,
-				role: 'ADMIN',
-			},
-		],
-	})
-
-	console.log(`✅ Создана команда "${team.name}" с 3 участниками`)
 
 	// Создание тестового приглашения
 	await prisma.teamInvitation.create({


### PR DESCRIPTION
## Что сделано

Модель `Project` была привязана только к пользователю (`createdById`),
без связи с командой. Это не позволяло выдавать список проектов команды
и проверять доступ по принадлежности к команде.

## Изменения

### `schema.prisma`
- В модель `Project` добавлены поля `teamId` и relation `team` с политикой
  `onDelete: Cascade` — при удалении команды все её проекты удаляются автоматически
- Добавлен `@@index([teamId])` для эффективных запросов `WHERE teamId = ?`
- В модель `Team` добавлена обратная связь `projects Project[]`
- В модель `Task` добавлен `onDelete: Cascade` на relation `project` —
  замкнута каскадная цепочка: Team → Project → Task

### Миграция
- Создан файл `20260503205712_add_team_id_to_project/migration.sql`

### `seed.ts`
- Блок создания команды и участников перенесён перед созданием проектов
- В оба `prisma.project.create()` добавлено поле `teamId: team.id`

## Проверка
- `pnpm prisma:seed` отрабатывает без ошибок
- Все 4 миграции применяются чисто через `migrate reset`
