### PR TITLE
feat(api): добавлен ProjectsModule — структура, DTO и сервис (#238)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ dist
 .settings/
 *.sublime-workspace
 
+.claude
+
 # IDE - VSCode
 .vscode/*
 !.vscode/settings.json

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -12,6 +12,7 @@ import { AuthModule } from './auth/auth.module'
 import { TeamsModule } from './teams/teams.module'
 import { CustomZodValidationPipe } from './common/providers/zod-validation.provider'
 import { RedisModule } from './common/redis/redis.module'
+import { ProjectsModule } from './projects/projects.module'
 
 @Module({
 	imports: [
@@ -21,6 +22,7 @@ import { RedisModule } from './common/redis/redis.module'
 		RedisModule,
 		AuthModule,
 		TeamsModule,
+		ProjectsModule,
 	],
 	controllers: [AppController],
 	providers: [

--- a/apps/api/src/projects/dto/create-project.dto.ts
+++ b/apps/api/src/projects/dto/create-project.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
+import { createProjectSchema } from '@repo/types'
+import { createZodDto } from 'nestjs-zod'
+
+export class createProjectDto extends createZodDto(createProjectSchema) {
+	@ApiProperty({
+		example: 'Dream Project',
+		description: 'Название проекта (1–50 символов)',
+	})
+	name: string
+
+	@ApiPropertyOptional({
+		example: 'My cool project',
+		description: 'Описание команды (до 500 символов)',
+	})
+	description: string
+}

--- a/apps/api/src/projects/dto/create-project.dto.ts
+++ b/apps/api/src/projects/dto/create-project.dto.ts
@@ -2,16 +2,16 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
 import { createProjectSchema } from '@repo/types'
 import { createZodDto } from 'nestjs-zod'
 
-export class createProjectDto extends createZodDto(createProjectSchema) {
+export class CreateProjectDto extends createZodDto(createProjectSchema) {
 	@ApiProperty({
 		example: 'Dream Project',
-		description: 'Название проекта (1–50 символов)',
+		description: 'Название проекта (1–100 символов)',
 	})
 	name: string
 
 	@ApiPropertyOptional({
 		example: 'My cool project',
-		description: 'Описание команды (до 500 символов)',
+		description: 'Описание проекта (до 500 символов)',
 	})
 	description?: string
 }

--- a/apps/api/src/projects/dto/project-response.dto.ts
+++ b/apps/api/src/projects/dto/project-response.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
+
+export class ProjectResponseDto {
+	@ApiProperty({ example: 'c1f2d3e4-5678-90ab-cdef-1234567890ab' })
+	id: string
+
+	@ApiProperty({ example: 'Backend Rewrite' })
+	name: string
+
+	@ApiPropertyOptional({ example: 'Полная переработка API на NestJS', nullable: true })
+	description: string | null
+
+	@ApiProperty({ example: 'a1b2c3d4-5678-90ab-cdef-1234567890ab' })
+	teamId: string
+
+	@ApiProperty({ example: 'f9e8d7c6-5432-10ab-cdef-0987654321ba' })
+	createdById: string
+
+	@ApiProperty({ example: '2024-01-15T10:30:00.000Z' })
+	createdAt: Date
+
+	@ApiProperty({ example: '2024-03-20T14:45:00.000Z' })
+	updatedAt: Date
+}

--- a/apps/api/src/projects/dto/update-project.dto.ts
+++ b/apps/api/src/projects/dto/update-project.dto.ts
@@ -2,16 +2,16 @@ import { ApiPropertyOptional } from '@nestjs/swagger'
 import { updateProjectSchema } from '@repo/types'
 import { createZodDto } from 'nestjs-zod'
 
-export class updateProjectDto extends createZodDto(updateProjectSchema) {
+export class UpdateProjectDto extends createZodDto(updateProjectSchema) {
 	@ApiPropertyOptional({
 		example: 'Dream Project',
-		description: 'Название проекта (1–50 символов)',
+		description: 'Название проекта (1–100 символов)',
 	})
 	name?: string
 
 	@ApiPropertyOptional({
 		example: 'My cool project',
-		description: 'Описание команды (до 500 символов)',
+		description: 'Описание проекта (до 500 символов)',
 	})
 	description?: string
 }

--- a/apps/api/src/projects/dto/update-project.dto.ts
+++ b/apps/api/src/projects/dto/update-project.dto.ts
@@ -1,13 +1,13 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
-import { createProjectSchema } from '@repo/types'
+import { ApiPropertyOptional } from '@nestjs/swagger'
+import { updateProjectSchema } from '@repo/types'
 import { createZodDto } from 'nestjs-zod'
 
-export class createProjectDto extends createZodDto(createProjectSchema) {
-	@ApiProperty({
+export class updateProjectDto extends createZodDto(updateProjectSchema) {
+	@ApiPropertyOptional({
 		example: 'Dream Project',
 		description: 'Название проекта (1–50 символов)',
 	})
-	name: string
+	name?: string
 
 	@ApiPropertyOptional({
 		example: 'My cool project',

--- a/apps/api/src/projects/projects.controller.ts
+++ b/apps/api/src/projects/projects.controller.ts
@@ -1,16 +1,33 @@
-import { Body, Controller, Param, Post, HttpCode, HttpStatus } from '@nestjs/common'
+import {
+	Body,
+	Controller,
+	Delete,
+	Get,
+	HttpCode,
+	HttpStatus,
+	Param,
+	Patch,
+	Post,
+	Query,
+} from '@nestjs/common'
 import {
 	ApiBearerAuth,
+	ApiCreatedResponse,
+	ApiForbiddenResponse,
+	ApiNotFoundResponse,
+	ApiOkResponse,
 	ApiOperation,
 	ApiTags,
-	ApiCreatedResponse,
-	ApiBadRequestResponse,
 } from '@nestjs/swagger'
-import { Authorization } from 'src/auth/decorators/authorization.decorator'
-import { ProjectsService } from './projects.service'
-import { Authorized } from 'src/auth/decorators/authorized.decorator'
+
+import { Authorization } from '../auth/decorators/authorization.decorator'
+import { Authorized } from '../auth/decorators/authorized.decorator'
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto'
+import { ApiPaginatedOkResponse } from '../utils/swagger.util'
 import { CreateProjectDto } from './dto/create-project.dto'
 import { ProjectResponseDto } from './dto/project-response.dto'
+import { UpdateProjectDto } from './dto/update-project.dto'
+import { ProjectsService } from './projects.service'
 
 @ApiTags('Projects')
 @ApiBearerAuth()
@@ -21,14 +38,69 @@ export class ProjectsController {
 
 	@ApiOperation({ summary: 'Создать проект' })
 	@ApiCreatedResponse({ type: ProjectResponseDto, description: 'Проект успешно создан' })
-	@ApiBadRequestResponse({ description: 'Некорректные данные' })
+	@ApiForbiddenResponse({ description: 'Вы не являетесь участником этой команды' })
 	@Post()
 	@HttpCode(HttpStatus.CREATED)
-	async create(
+	create(
 		@Param('teamId') teamId: string,
 		@Authorized('id') userId: string,
 		@Body() dto: CreateProjectDto,
 	) {
 		return this.projectsService.create(teamId, userId, dto)
+	}
+
+	@ApiOperation({ summary: 'Список проектов команды' })
+	@ApiPaginatedOkResponse(ProjectResponseDto, 'Пагинированный список проектов')
+	@ApiForbiddenResponse({ description: 'Вы не являетесь участником этой команды' })
+	@Get()
+	findAll(
+		@Param('teamId') teamId: string,
+		@Authorized('id') userId: string,
+		@Query() pagination: PaginationQueryDto,
+	) {
+		return this.projectsService.findAllByTeam(teamId, userId, pagination)
+	}
+
+	@ApiOperation({ summary: 'Получить проект по ID' })
+	@ApiOkResponse({ type: ProjectResponseDto, description: 'Данные проекта' })
+	@ApiNotFoundResponse({ description: 'Проект не найден' })
+	@ApiForbiddenResponse({ description: 'Вы не являетесь участником этой команды' })
+	@Get(':projectId')
+	findOne(
+		@Param('teamId') teamId: string,
+		@Param('projectId') projectId: string,
+		@Authorized('id') userId: string,
+	) {
+		return this.projectsService.findOne(teamId, projectId, userId)
+	}
+
+	@ApiOperation({ summary: 'Обновить проект (OWNER / ADMIN / создатель)' })
+	@ApiOkResponse({ type: ProjectResponseDto, description: 'Проект обновлён' })
+	@ApiNotFoundResponse({ description: 'Проект не найден' })
+	@ApiForbiddenResponse({ description: 'Недостаточно прав для обновления проекта' })
+	@Patch(':projectId')
+	update(
+		@Param('teamId') teamId: string,
+		@Param('projectId') projectId: string,
+		@Authorized('id') userId: string,
+		@Body() dto: UpdateProjectDto,
+	) {
+		return this.projectsService.update(teamId, projectId, userId, dto)
+	}
+
+	@ApiOperation({ summary: 'Удалить проект (OWNER / ADMIN)' })
+	@ApiOkResponse({
+		description: 'Проект удалён',
+		schema: { example: { message: 'Проект успешно удалён', success: true } },
+	})
+	@ApiNotFoundResponse({ description: 'Проект не найден' })
+	@ApiForbiddenResponse({ description: 'Недостаточно прав для удаления проекта' })
+	@Delete(':projectId')
+	remove(
+		@Param('teamId') teamId: string,
+		@Param('projectId') projectId: string,
+		@Authorized('id') userId: string,
+	) {
+		return this.projectsService.remove(teamId, projectId, userId)
 	}
 }

--- a/apps/api/src/projects/projects.controller.ts
+++ b/apps/api/src/projects/projects.controller.ts
@@ -1,0 +1,34 @@
+import { Body, Controller, Param, Post, HttpCode, HttpStatus } from '@nestjs/common'
+import {
+	ApiBearerAuth,
+	ApiOperation,
+	ApiTags,
+	ApiCreatedResponse,
+	ApiBadRequestResponse,
+} from '@nestjs/swagger'
+import { Authorization } from 'src/auth/decorators/authorization.decorator'
+import { ProjectsService } from './projects.service'
+import { Authorized } from 'src/auth/decorators/authorized.decorator'
+import { CreateProjectDto } from './dto/create-project.dto'
+import { ProjectResponseDto } from './dto/project-response.dto'
+
+@ApiTags('Projects')
+@ApiBearerAuth()
+@Authorization()
+@Controller('teams/:teamId/projects')
+export class ProjectsController {
+	constructor(private readonly projectsService: ProjectsService) {}
+
+	@ApiOperation({ summary: 'Создать проект' })
+	@ApiCreatedResponse({ type: ProjectResponseDto, description: 'Проект успешно создан' })
+	@ApiBadRequestResponse({ description: 'Некорректные данные' })
+	@Post()
+	@HttpCode(HttpStatus.CREATED)
+	async create(
+		@Param('teamId') teamId: string,
+		@Authorized('id') userId: string,
+		@Body() dto: CreateProjectDto,
+	) {
+		return this.projectsService.create(teamId, userId, dto)
+	}
+}

--- a/apps/api/src/projects/projects.module.ts
+++ b/apps/api/src/projects/projects.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common'
+import { ProjectsService } from './projects.service'
+
+@Module({
+	providers: [ProjectsService],
+})
+export class ProjectsModule {}

--- a/apps/api/src/projects/projects.module.ts
+++ b/apps/api/src/projects/projects.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common'
 import { ProjectsService } from './projects.service'
+import { ProjectsController } from './projects.controller'
 
 @Module({
 	providers: [ProjectsService],
+	controllers: [ProjectsController],
 })
 export class ProjectsModule {}

--- a/apps/api/src/projects/projects.service.ts
+++ b/apps/api/src/projects/projects.service.ts
@@ -1,0 +1,59 @@
+import { ForbiddenException, Injectable } from '@nestjs/common'
+import type { TeamMember } from 'generated/prisma/client'
+import { CreateProjectDto } from './dto/create-project.dto'
+import { PrismaService } from '../../prisma/prisma.service'
+import {
+	buildPaginatedResponse,
+	getPaginationPrismaParams,
+	PaginationOptions,
+} from '../utils/pagination.util'
+
+@Injectable()
+export class ProjectsService {
+	constructor(private readonly prisma: PrismaService) {}
+
+	private async assertTeamMember(teamId: string, userId: string): Promise<TeamMember> {
+		const member = await this.prisma.teamMember.findUnique({
+			where: { teamId_userId: { teamId, userId } },
+		})
+
+		if (!member) {
+			throw new ForbiddenException('У вас нет доступа к этой команде')
+		}
+
+		return member
+	}
+
+	async create(teamId: string, userId: string, dto: CreateProjectDto) {
+		await this.assertTeamMember(teamId, userId)
+
+		return this.prisma.project.create({
+			data: {
+				name: dto.name,
+				description: dto.description,
+				teamId,
+				createdById: userId,
+			},
+		})
+	}
+
+	async findAllByTeam(teamId: string, userId: string, pagination: PaginationOptions) {
+		await this.assertTeamMember(teamId, userId)
+
+		const { take, skip } = getPaginationPrismaParams(pagination)
+
+		const [projects, totalCount] = await Promise.all([
+			this.prisma.project.findMany({
+				where: { teamId },
+				take,
+				skip,
+				orderBy: {
+					createdAt: 'desc',
+				},
+			}),
+			this.prisma.project.count({ where: { teamId } }),
+		])
+
+		return buildPaginatedResponse(projects, pagination, totalCount)
+	}
+}

--- a/apps/api/src/projects/projects.service.ts
+++ b/apps/api/src/projects/projects.service.ts
@@ -1,4 +1,4 @@
-import { ForbiddenException, Injectable } from '@nestjs/common'
+import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common'
 import type { TeamMember } from 'generated/prisma/client'
 import { CreateProjectDto } from './dto/create-project.dto'
 import { PrismaService } from '../../prisma/prisma.service'
@@ -55,5 +55,21 @@ export class ProjectsService {
 		])
 
 		return buildPaginatedResponse(projects, pagination, totalCount)
+	}
+
+	async findOne(teamId: string, projectId: string, userId: string) {
+		await this.assertTeamMember(teamId, userId)
+
+		const project = await this.prisma.project.findUnique({ where: { id: projectId } })
+
+		if (!project) {
+			throw new NotFoundException('Проект не найден')
+		}
+
+		if (project.teamId !== teamId) {
+			throw new NotFoundException('Проект не относится к этой команде')
+		}
+
+		return project
 	}
 }

--- a/apps/api/src/projects/projects.service.ts
+++ b/apps/api/src/projects/projects.service.ts
@@ -115,6 +115,8 @@ export class ProjectsService {
 
 		this.assertCanModify(member, project, 'delete')
 
-		return this.prisma.project.delete({ where: { id: projectId } })
+		await this.prisma.project.delete({ where: { id: projectId } })
+
+		return { message: 'Проект успешно удалён', success: true }
 	}
 }

--- a/apps/api/src/projects/projects.service.ts
+++ b/apps/api/src/projects/projects.service.ts
@@ -5,7 +5,7 @@ import { PrismaService } from '../../prisma/prisma.service'
 import {
 	buildPaginatedResponse,
 	getPaginationPrismaParams,
-	PaginationOptions,
+	type PaginationOptions,
 } from '../utils/pagination.util'
 import { UpdateProjectDto } from './dto/update-project.dto'
 
@@ -100,6 +100,21 @@ export class ProjectsService {
 
 		this.assertCanModify(member, project, 'update')
 
-		return this.prisma.project.update({ where: { id: projectId }, data: dto })
+		return this.prisma.project.update({
+			where: { id: projectId },
+			data: {
+				name: dto.name,
+				description: dto.description,
+			},
+		})
+	}
+
+	async remove(teamId: string, projectId: string, userId: string) {
+		const member = await this.assertTeamMember(teamId, userId)
+		const project = await this.findProjectOrThrow(teamId, projectId)
+
+		this.assertCanModify(member, project, 'delete')
+
+		return this.prisma.project.delete({ where: { id: projectId } })
 	}
 }

--- a/apps/api/src/projects/projects.service.ts
+++ b/apps/api/src/projects/projects.service.ts
@@ -1,5 +1,5 @@
 import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common'
-import type { TeamMember } from 'generated/prisma/client'
+import type { Project, TeamMember } from 'generated/prisma/client'
 import { CreateProjectDto } from './dto/create-project.dto'
 import { PrismaService } from '../../prisma/prisma.service'
 import {
@@ -7,6 +7,7 @@ import {
 	getPaginationPrismaParams,
 	PaginationOptions,
 } from '../utils/pagination.util'
+import { UpdateProjectDto } from './dto/update-project.dto'
 
 @Injectable()
 export class ProjectsService {
@@ -22,6 +23,35 @@ export class ProjectsService {
 		}
 
 		return member
+	}
+
+	private assertCanModify(
+		member: TeamMember,
+		project: Project,
+		action: 'update' | 'delete',
+	) {
+		const isAdminOrOwner = member.role === 'ADMIN' || member.role === 'OWNER'
+		const isCreator = project.createdById === member.userId
+
+		const canModify = action === 'delete' ? isAdminOrOwner : isAdminOrOwner || isCreator
+
+		if (!canModify) {
+			throw new ForbiddenException('Недостаточно прав для выполнения этого действия')
+		}
+	}
+
+	private async findProjectOrThrow(teamId: string, projectId: string) {
+		const project = await this.prisma.project.findUnique({ where: { id: projectId } })
+
+		if (!project) {
+			throw new NotFoundException('Проект не найден')
+		}
+
+		if (project.teamId !== teamId) {
+			throw new NotFoundException('Проект не относится к этой команде')
+		}
+
+		return project
 	}
 
 	async create(teamId: string, userId: string, dto: CreateProjectDto) {
@@ -60,16 +90,16 @@ export class ProjectsService {
 	async findOne(teamId: string, projectId: string, userId: string) {
 		await this.assertTeamMember(teamId, userId)
 
-		const project = await this.prisma.project.findUnique({ where: { id: projectId } })
+		return this.findProjectOrThrow(teamId, projectId)
+	}
 
-		if (!project) {
-			throw new NotFoundException('Проект не найден')
-		}
+	async update(teamId: string, projectId: string, userId: string, dto: UpdateProjectDto) {
+		const member = await this.assertTeamMember(teamId, userId)
 
-		if (project.teamId !== teamId) {
-			throw new NotFoundException('Проект не относится к этой команде')
-		}
+		const project = await this.findProjectOrThrow(teamId, projectId)
 
-		return project
+		this.assertCanModify(member, project, 'update')
+
+		return this.prisma.project.update({ where: { id: projectId }, data: dto })
 	}
 }

--- a/apps/api/test/helpers/projects.helpers.ts
+++ b/apps/api/test/helpers/projects.helpers.ts
@@ -1,0 +1,71 @@
+import { vi } from 'vitest'
+import { PrismaService } from '../../prisma/prisma.service'
+import { TEAM_ID, USER_ID } from './teams.helpers'
+
+export { TEAM_ID, USER_ID }
+
+export function createPrismaMock() {
+	return {
+		teamMember: {
+			findUnique: vi.fn(),
+		},
+		project: {
+			create: vi.fn(),
+			findMany: vi.fn(),
+			findUnique: vi.fn(),
+			count: vi.fn(),
+			update: vi.fn(),
+			delete: vi.fn(),
+		},
+	} as unknown as PrismaService & {
+		teamMember: {
+			findUnique: ReturnType<typeof vi.fn>
+		}
+		project: {
+			create: ReturnType<typeof vi.fn>
+			findMany: ReturnType<typeof vi.fn>
+			findUnique: ReturnType<typeof vi.fn>
+			count: ReturnType<typeof vi.fn>
+			update: ReturnType<typeof vi.fn>
+			delete: ReturnType<typeof vi.fn>
+		}
+	}
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+export const PROJECT_ID = 'project-id-1'
+
+export const MEMBER_OWNER = {
+	id: 'member-id-1',
+	teamId: TEAM_ID,
+	userId: USER_ID,
+	role: 'OWNER' as const,
+	joinedAt: new Date(),
+}
+
+export const MEMBER_ADMIN = {
+	id: 'member-id-2',
+	teamId: TEAM_ID,
+	userId: 'user-id-admin',
+	role: 'ADMIN' as const,
+	joinedAt: new Date(),
+}
+
+export const MEMBER_PLAIN = {
+	id: 'member-id-3',
+	teamId: TEAM_ID,
+	userId: 'user-id-plain',
+	role: 'MEMBER' as const,
+	joinedAt: new Date(),
+}
+
+export const MOCK_PROJECT = {
+	id: PROJECT_ID,
+	name: 'Backend Rewrite',
+	description: null,
+	teamId: TEAM_ID,
+	createdById: USER_ID,
+	createdAt: new Date(),
+	updatedAt: new Date(),
+}

--- a/apps/api/test/unit/projects/projects.service.spec.ts
+++ b/apps/api/test/unit/projects/projects.service.spec.ts
@@ -1,0 +1,266 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ProjectsService } from '../../../src/projects/projects.service'
+import {
+	createPrismaMock,
+	MEMBER_ADMIN,
+	MEMBER_OWNER,
+	MEMBER_PLAIN,
+	MOCK_PROJECT,
+	PROJECT_ID,
+	TEAM_ID,
+	USER_ID,
+} from '../../helpers/projects.helpers'
+
+// ── suite ─────────────────────────────────────────────────────────────────────
+describe('ProjectsService', () => {
+	let service: ProjectsService
+	let prisma: ReturnType<typeof createPrismaMock>
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		prisma = createPrismaMock()
+		service = new ProjectsService(prisma)
+	})
+
+	// ── create ────────────────────────────────────────────────────────────────
+	describe('create', () => {
+		it('должен создать проект если пользователь — участник команды', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.project.create.mockResolvedValue(MOCK_PROJECT)
+
+			const dto = { name: 'Backend Rewrite' }
+			const result = await service.create(TEAM_ID, USER_ID, dto as never)
+
+			expect(prisma.teamMember.findUnique).toHaveBeenCalledWith(
+				expect.objectContaining({
+					where: { teamId_userId: { teamId: TEAM_ID, userId: USER_ID } },
+				}),
+			)
+			expect(prisma.project.create).toHaveBeenCalledWith(
+				expect.objectContaining({
+					data: expect.objectContaining({
+						name: 'Backend Rewrite',
+						teamId: TEAM_ID,
+						createdById: USER_ID,
+					}),
+				}),
+			)
+			expect(result).toEqual(MOCK_PROJECT)
+		})
+
+		it('должен выбросить ForbiddenException если пользователь не участник команды', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(null)
+
+			await expect(
+				service.create(TEAM_ID, USER_ID, { name: 'X' } as never),
+			).rejects.toThrow(ForbiddenException)
+
+			expect(prisma.project.create).not.toHaveBeenCalled()
+		})
+	})
+
+	// ── findAllByTeam ─────────────────────────────────────────────────────────
+	describe('findAllByTeam', () => {
+		it('должен вернуть пагинированный список проектов команды', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.project.findMany.mockResolvedValue([MOCK_PROJECT])
+			prisma.project.count.mockResolvedValue(1)
+
+			const result = await service.findAllByTeam(TEAM_ID, USER_ID, { page: 1, limit: 10 })
+
+			expect(prisma.project.findMany).toHaveBeenCalledWith(
+				expect.objectContaining({
+					where: { teamId: TEAM_ID },
+					skip: 0,
+					take: 10,
+					orderBy: { createdAt: 'desc' },
+				}),
+			)
+			expect(result).toEqual({
+				data: [MOCK_PROJECT],
+				meta: { page: 1, limit: 10, total: 1, totalPages: 1 },
+			})
+		})
+
+		it('должен вернуть пустой список если проектов нет', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.project.findMany.mockResolvedValue([])
+			prisma.project.count.mockResolvedValue(0)
+
+			const result = await service.findAllByTeam(TEAM_ID, USER_ID, { page: 1, limit: 10 })
+
+			expect(result).toEqual({
+				data: [],
+				meta: { page: 1, limit: 10, total: 0, totalPages: 0 },
+			})
+		})
+
+		it('должен выбросить ForbiddenException если пользователь не участник команды', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(null)
+
+			await expect(
+				service.findAllByTeam(TEAM_ID, USER_ID, { page: 1, limit: 10 }),
+			).rejects.toThrow(ForbiddenException)
+
+			expect(prisma.project.findMany).not.toHaveBeenCalled()
+		})
+	})
+
+	// ── findOne ───────────────────────────────────────────────────────────────
+	describe('findOne', () => {
+		it('должен вернуть проект если пользователь — участник команды', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.project.findUnique.mockResolvedValue(MOCK_PROJECT)
+
+			const result = await service.findOne(TEAM_ID, PROJECT_ID, USER_ID)
+
+			expect(prisma.project.findUnique).toHaveBeenCalledWith(
+				expect.objectContaining({ where: { id: PROJECT_ID } }),
+			)
+			expect(result).toEqual(MOCK_PROJECT)
+		})
+
+		it('должен выбросить NotFoundException если проект не найден', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.project.findUnique.mockResolvedValue(null)
+
+			await expect(service.findOne(TEAM_ID, PROJECT_ID, USER_ID)).rejects.toThrow(
+				NotFoundException,
+			)
+			await expect(service.findOne(TEAM_ID, PROJECT_ID, USER_ID)).rejects.toThrow(
+				'Проект не найден',
+			)
+		})
+
+		it('должен выбросить NotFoundException если проект принадлежит другой команде (IDOR)', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.project.findUnique.mockResolvedValue({
+				...MOCK_PROJECT,
+				teamId: 'other-team-id',
+			})
+
+			await expect(service.findOne(TEAM_ID, PROJECT_ID, USER_ID)).rejects.toThrow(
+				NotFoundException,
+			)
+		})
+
+		it('должен выбросить ForbiddenException если пользователь не участник команды', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(null)
+
+			await expect(service.findOne(TEAM_ID, PROJECT_ID, USER_ID)).rejects.toThrow(
+				ForbiddenException,
+			)
+		})
+	})
+
+	// ── update ────────────────────────────────────────────────────────────────
+	describe('update', () => {
+		it('OWNER должен обновить проект', async () => {
+			const updated = { ...MOCK_PROJECT, name: 'New Name' }
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.project.findUnique.mockResolvedValue(MOCK_PROJECT)
+			prisma.project.update.mockResolvedValue(updated)
+
+			const result = await service.update(TEAM_ID, PROJECT_ID, USER_ID, {
+				name: 'New Name',
+			} as never)
+
+			expect(prisma.project.update).toHaveBeenCalledWith(
+				expect.objectContaining({ where: { id: PROJECT_ID } }),
+			)
+			expect(result).toEqual(updated)
+		})
+
+		it('ADMIN должен обновить проект', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_ADMIN)
+			prisma.project.findUnique.mockResolvedValue(MOCK_PROJECT)
+			prisma.project.update.mockResolvedValue(MOCK_PROJECT)
+
+			await expect(
+				service.update(TEAM_ID, PROJECT_ID, MEMBER_ADMIN.userId, { name: 'X' } as never),
+			).resolves.not.toThrow()
+		})
+
+		it('создатель проекта с ролью MEMBER должен иметь право обновить проект', async () => {
+			// MEMBER чей userId === project.createdById
+			const creatorMember = { ...MEMBER_PLAIN, userId: USER_ID, role: 'MEMBER' as const }
+			prisma.teamMember.findUnique.mockResolvedValue(creatorMember)
+			prisma.project.findUnique.mockResolvedValue(MOCK_PROJECT) // createdById === USER_ID
+			prisma.project.update.mockResolvedValue(MOCK_PROJECT)
+
+			await expect(
+				service.update(TEAM_ID, PROJECT_ID, USER_ID, { name: 'X' } as never),
+			).resolves.not.toThrow()
+		})
+
+		it('MEMBER не создатель должен получить ForbiddenException', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_PLAIN) // userId !== createdById
+			prisma.project.findUnique.mockResolvedValue(MOCK_PROJECT) // createdById === USER_ID
+
+			await expect(
+				service.update(TEAM_ID, PROJECT_ID, MEMBER_PLAIN.userId, { name: 'X' } as never),
+			).rejects.toThrow(ForbiddenException)
+
+			expect(prisma.project.update).not.toHaveBeenCalled()
+		})
+
+		it('должен выбросить ForbiddenException если пользователь не участник команды', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(null)
+
+			await expect(
+				service.update(TEAM_ID, PROJECT_ID, USER_ID, { name: 'X' } as never),
+			).rejects.toThrow(ForbiddenException)
+
+			expect(prisma.project.update).not.toHaveBeenCalled()
+		})
+	})
+
+	// ── remove ────────────────────────────────────────────────────────────────
+	describe('remove', () => {
+		it('OWNER должен удалить проект и вернуть подтверждение', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.project.findUnique.mockResolvedValue(MOCK_PROJECT)
+			prisma.project.delete.mockResolvedValue(MOCK_PROJECT)
+
+			const result = await service.remove(TEAM_ID, PROJECT_ID, USER_ID)
+
+			expect(prisma.project.delete).toHaveBeenCalledWith({ where: { id: PROJECT_ID } })
+			expect(result).toEqual({ message: 'Проект успешно удалён', success: true })
+		})
+
+		it('ADMIN должен удалить проект', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_ADMIN)
+			prisma.project.findUnique.mockResolvedValue(MOCK_PROJECT)
+			prisma.project.delete.mockResolvedValue(MOCK_PROJECT)
+
+			await expect(
+				service.remove(TEAM_ID, PROJECT_ID, MEMBER_ADMIN.userId),
+			).resolves.toEqual({ message: 'Проект успешно удалён', success: true })
+		})
+
+		it('MEMBER (даже создатель) не должен иметь право удалять проект', async () => {
+			// Создатель с ролью MEMBER
+			const creatorMember = { ...MEMBER_PLAIN, userId: USER_ID, role: 'MEMBER' as const }
+			prisma.teamMember.findUnique.mockResolvedValue(creatorMember)
+			prisma.project.findUnique.mockResolvedValue(MOCK_PROJECT)
+
+			await expect(service.remove(TEAM_ID, PROJECT_ID, USER_ID)).rejects.toThrow(
+				ForbiddenException,
+			)
+
+			expect(prisma.project.delete).not.toHaveBeenCalled()
+		})
+
+		it('должен выбросить ForbiddenException если пользователь не участник команды', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(null)
+
+			await expect(service.remove(TEAM_ID, PROJECT_ID, USER_ID)).rejects.toThrow(
+				ForbiddenException,
+			)
+
+			expect(prisma.project.delete).not.toHaveBeenCalled()
+		})
+	})
+})

--- a/packages/types/src/projects/index.ts
+++ b/packages/types/src/projects/index.ts
@@ -1,1 +1,3 @@
 export * from './types/project.types'
+export * from './schemas/create-project.schema'
+export * from './schemas/update-project.schema'

--- a/packages/types/src/projects/schemas/create-project.schema.ts
+++ b/packages/types/src/projects/schemas/create-project.schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod'
+
+export const createProjectSchema = z.object({
+	name: z
+		.string({ message: 'Название должно быть строкой' })
+		.min(1, { message: 'Название должно быть не менее 1 символа' })
+		.max(100, { message: 'Название должно быть не длиннее 100 символов' }),
+	description: z
+		.string({ message: 'Описание должно быть строкой' })
+		.max(500, { message: 'Описание должно быть не длиннее 500 символов' })
+		.optional(),
+})
+
+export type CreateProject = z.infer<typeof createProjectSchema>

--- a/packages/types/src/projects/schemas/update-project.schema.ts
+++ b/packages/types/src/projects/schemas/update-project.schema.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod'
+import { createProjectSchema } from './create-project.schema'
+
+export const updateProjectSchema = createProjectSchema.partial()
+
+export type UpdateProject = z.infer<typeof updateProjectSchema>


### PR DESCRIPTION
## Что сделано

Реализован `ProjectsModule` без контроллера — вся бизнес-логика
инкапсулирована в сервисе.

## Изменения

### `packages/types`
- Добавлены Zod-схемы `createProjectSchema` и `updateProjectSchema`
- Обновлён `index.ts` — реэкспорт новых схем

### `apps/api/src/projects/`
- `CreateProjectDto` / `UpdateProjectDto` — валидация через nestjs-zod
- `ProjectResponseDto` — Swagger-контракт ответа
- `ProjectsService` — полная бизнес-логика:
  - `create` — создание проекта с проверкой членства в команде
  - `findAllByTeam` — список проектов с пагинацией
  - `findOne` — получение проекта с IDOR-защитой
  - `update` — обновление (доступно OWNER / ADMIN / создателю проекта)
  - `remove` — удаление (доступно только OWNER / ADMIN)
- `ProjectsModule` — зарегистрирован в `AppModule`

## Архитектурные решения

- **Defence in depth** — авторизация в сервисе, не только на уровне guard
- **IDOR-защита** — проверка `project.teamId === teamId` при каждом обращении
- **Матрица прав**: `update` — OWNER/ADMIN/creator, `remove` — OWNER/ADMIN
- **Переиспользование** — `findProjectOrThrow` вынесен отдельно,
  исключает дублирование в `findOne` / `update` / `remove`