### PR TITLE
chore(api): добави поля position и dueDate в модель Task

### DIFF
--- a/apps/api/prisma/migrations/20260619082553_add_task_position_duedate/migration.sql
+++ b/apps/api/prisma/migrations/20260619082553_add_task_position_duedate/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "Task" ADD COLUMN     "dueDate" TIMESTAMP(3),
+ADD COLUMN     "position" INTEGER NOT NULL DEFAULT 0;
+
+-- CreateIndex
+CREATE INDEX "Task_projectId_status_position_idx" ON "Task"("projectId", "status", "position");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -116,10 +116,14 @@ model Task {
   description String?
   status      TaskStatus @default(TODO)
   priority    Priority   @default(MEDIUM)
+  position    Int        @default(0)
+  dueDate     DateTime?
   projectId   String
   project     Project    @relation(fields: [projectId], references: [id], onDelete: Cascade)
   assigneeId  String?
   assignee    User?      @relation(fields: [assigneeId], references: [id])
   createdAt   DateTime   @default(now())
   updatedAt   DateTime   @updatedAt
+
+  @@index([projectId, status, position])
 }


### PR DESCRIPTION
## 🚀 Что было сделано
- **Модель Task (`schema.prisma`):**
  - Добавлено поле `position` (`Int`, дефолт `0`) — для фиксации порядка задач внутри колонок.
  - Добавлено опциональное поле `dueDate` (`DateTime?`) — для указания дедлайнов.
  - Добавлен составной индекс `@@index([projectId, status, position])` — для ускорения фильтрации и сортировки задач при рендере доски проекта.
- **Миграция:** Сгенерирована и успешно применена локальная миграция `add-task-position-duedate`.
