### PR TITLE
feat(api): реализовать создание задачи с расчетом position по TDD

### DIFF
--- a/apps/api/src/tasks/dto/create-task.dto.ts
+++ b/apps/api/src/tasks/dto/create-task.dto.ts
@@ -1,0 +1,43 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
+import { type Priority, type TaskStatus, createTaskSchema } from '@repo/types'
+import { createZodDto } from 'nestjs-zod'
+
+export class CreateTaskDto extends createZodDto(createTaskSchema) {
+	@ApiProperty({
+		example: 'Fix login bug',
+		description: 'Название задачи (1–255 символов)',
+	})
+	title: string
+
+	@ApiPropertyOptional({
+		example: 'The login form breaks on mobile Safari',
+		description: 'Описание задачи (до 5000 символов)',
+	})
+	description?: string
+
+	@ApiPropertyOptional({
+		example: 'TODO',
+		enum: ['TODO', 'BACKLOG', 'IN_PROGRESS', 'IN_REVIEW', 'DONE'],
+		description: 'Статус задачи',
+	})
+	status?: TaskStatus
+
+	@ApiPropertyOptional({
+		example: 'MEDIUM',
+		enum: ['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'],
+		description: 'Приоритет задачи',
+	})
+	priority?: Priority
+
+	@ApiPropertyOptional({
+		example: 'user-uuid',
+		description: 'ID исполнителя',
+	})
+	assigneeId?: string
+
+	@ApiPropertyOptional({
+		example: '2025-12-31T23:59:59.000Z',
+		description: 'Дедлайн задачи в формате ISO 8601',
+	})
+	dueDate?: string
+}

--- a/apps/api/src/tasks/tasks.service.ts
+++ b/apps/api/src/tasks/tasks.service.ts
@@ -1,4 +1,63 @@
-import { Injectable } from '@nestjs/common'
+import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common'
+import { TaskStatus, type TeamMember } from 'generated/prisma/client'
+import { PrismaService } from '../../prisma/prisma.service'
+import { CreateTaskDto } from './dto/create-task.dto'
 
 @Injectable()
-export class TasksService {}
+export class TasksService {
+	constructor(private readonly prisma: PrismaService) {}
+
+	private async assertTeamMember(teamId: string, userId: string): Promise<TeamMember> {
+		const member = await this.prisma.teamMember.findUnique({
+			where: { teamId_userId: { teamId, userId } },
+		})
+
+		if (!member) {
+			throw new ForbiddenException('У вас нет доступа к этой команде')
+		}
+
+		return member
+	}
+
+	private async findProjectOrThrow(teamId: string, projectId: string) {
+		const project = await this.prisma.project.findUnique({ where: { id: projectId } })
+
+		if (!project) {
+			throw new NotFoundException('Проект не найден')
+		}
+
+		if (project.teamId !== teamId) {
+			throw new NotFoundException('Проект не относится к этой команде')
+		}
+
+		return project
+	}
+
+	async create(teamId: string, projectId: string, userId: string, dto: CreateTaskDto) {
+		await this.assertTeamMember(teamId, userId)
+		await this.findProjectOrThrow(teamId, projectId)
+
+		const status = dto.status ?? TaskStatus.TODO
+
+		const aggregate = await this.prisma.task.aggregate({
+			where: { projectId, status: status as never },
+			_max: { position: true },
+		})
+
+		const maxPosition = aggregate._max.position
+		const position = maxPosition === null ? 1 : maxPosition + 1
+
+		return this.prisma.task.create({
+			data: {
+				title: dto.title,
+				description: dto.description,
+				status: status as never,
+				priority: dto.priority as never,
+				assigneeId: dto.assigneeId,
+				dueDate: dto.dueDate ? new Date(dto.dueDate) : undefined,
+				projectId,
+				position,
+			},
+		})
+	}
+}

--- a/apps/api/test/helpers/tasks.helpers.ts
+++ b/apps/api/test/helpers/tasks.helpers.ts
@@ -1,0 +1,72 @@
+import { vi } from 'vitest'
+import { PrismaService } from '../../prisma/prisma.service'
+import { TEAM_ID, USER_ID } from './teams.helpers'
+
+export { TEAM_ID, USER_ID }
+
+export function createPrismaMock() {
+	return {
+		teamMember: {
+			findUnique: vi.fn(),
+		},
+		project: {
+			findUnique: vi.fn(),
+		},
+		task: {
+			aggregate: vi.fn(),
+			create: vi.fn(),
+		},
+	} as unknown as PrismaService & {
+		teamMember: {
+			findUnique: ReturnType<typeof vi.fn>
+		}
+		project: {
+			findUnique: ReturnType<typeof vi.fn>
+		}
+		task: {
+			aggregate: ReturnType<typeof vi.fn>
+			create: ReturnType<typeof vi.fn>
+		}
+	}
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+export const PROJECT_ID = 'project-id-1'
+export const TASK_ID = 'task-id-1'
+
+export const MEMBER_OWNER = {
+	id: 'member-id-1',
+	teamId: TEAM_ID,
+	userId: USER_ID,
+	role: 'OWNER' as const,
+	joinedAt: new Date(),
+}
+
+export const MOCK_PROJECT = {
+	id: PROJECT_ID,
+	name: 'Backend Rewrite',
+	description: null,
+	teamId: TEAM_ID,
+	createdById: USER_ID,
+	createdAt: new Date(),
+	updatedAt: new Date(),
+}
+
+export const MOCK_TASK = {
+	id: TASK_ID,
+	title: 'Fix login bug',
+	description: null,
+	status: 'TODO' as const,
+	priority: 'MEDIUM' as const,
+	position: 1,
+	dueDate: null,
+	projectId: PROJECT_ID,
+	assigneeId: null,
+	createdAt: new Date(),
+	updatedAt: new Date(),
+}
+
+export const CREATE_TASK_DTO = {
+	title: 'Fix login bug',
+}

--- a/apps/api/test/unit/tasks/tasks.service.spec.ts
+++ b/apps/api/test/unit/tasks/tasks.service.spec.ts
@@ -1,0 +1,121 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { TasksService } from '../../../src/tasks/tasks.service'
+import {
+	createPrismaMock,
+	CREATE_TASK_DTO,
+	MEMBER_OWNER,
+	MOCK_PROJECT,
+	MOCK_TASK,
+	PROJECT_ID,
+	TEAM_ID,
+	USER_ID,
+} from '../../helpers/tasks.helpers'
+
+// ── suite ─────────────────────────────────────────────────────────────────────
+describe('TasksService', () => {
+	let service: TasksService
+	let prisma: ReturnType<typeof createPrismaMock>
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		prisma = createPrismaMock()
+		service = new TasksService(prisma)
+	})
+
+	// ── create ────────────────────────────────────────────────────────────────
+	describe('create', () => {
+		it('должен создать задачу с position = 1 если задач с таким статусом ещё нет', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.project.findUnique.mockResolvedValue(MOCK_PROJECT)
+			// aggregate returns null when no tasks exist yet
+			prisma.task.aggregate.mockResolvedValue({ _max: { position: null } })
+			prisma.task.create.mockResolvedValue(MOCK_TASK)
+
+			const result = await service.create(
+				TEAM_ID,
+				PROJECT_ID,
+				USER_ID,
+				CREATE_TASK_DTO as never,
+			)
+
+			expect(prisma.teamMember.findUnique).toHaveBeenCalledWith(
+				expect.objectContaining({
+					where: { teamId_userId: { teamId: TEAM_ID, userId: USER_ID } },
+				}),
+			)
+			expect(prisma.project.findUnique).toHaveBeenCalledWith(
+				expect.objectContaining({ where: { id: PROJECT_ID } }),
+			)
+			expect(prisma.task.aggregate).toHaveBeenCalledWith(
+				expect.objectContaining({
+					where: { projectId: PROJECT_ID, status: 'TODO' },
+					_max: { position: true },
+				}),
+			)
+			expect(prisma.task.create).toHaveBeenCalledWith(
+				expect.objectContaining({
+					data: expect.objectContaining({
+						title: CREATE_TASK_DTO.title,
+						projectId: PROJECT_ID,
+						position: 1,
+					}),
+				}),
+			)
+			expect(result).toEqual(MOCK_TASK)
+		})
+
+		it('должен создать задачу с position = MAX + 1 если задачи уже существуют', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.project.findUnique.mockResolvedValue(MOCK_PROJECT)
+			prisma.task.aggregate.mockResolvedValue({ _max: { position: 5 } })
+			prisma.task.create.mockResolvedValue({ ...MOCK_TASK, position: 6 })
+
+			await service.create(TEAM_ID, PROJECT_ID, USER_ID, CREATE_TASK_DTO as never)
+
+			expect(prisma.task.create).toHaveBeenCalledWith(
+				expect.objectContaining({
+					data: expect.objectContaining({
+						position: 6,
+					}),
+				}),
+			)
+		})
+
+		it('должен выбросить ForbiddenException если пользователь не является членом команды', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(null)
+
+			await expect(
+				service.create(TEAM_ID, PROJECT_ID, USER_ID, CREATE_TASK_DTO as never),
+			).rejects.toThrow(ForbiddenException)
+
+			expect(prisma.task.create).not.toHaveBeenCalled()
+		})
+
+		it('должен выбросить NotFoundException если проект не найден', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.project.findUnique.mockResolvedValue(null)
+
+			await expect(
+				service.create(TEAM_ID, PROJECT_ID, USER_ID, CREATE_TASK_DTO as never),
+			).rejects.toThrow(NotFoundException)
+
+			expect(prisma.task.create).not.toHaveBeenCalled()
+		})
+
+		it('должен выбросить NotFoundException если проект не принадлежит указанной команде', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.project.findUnique.mockResolvedValue({
+				...MOCK_PROJECT,
+				teamId: 'other-team-id',
+			})
+
+			await expect(
+				service.create(TEAM_ID, PROJECT_ID, USER_ID, CREATE_TASK_DTO as never),
+			).rejects.toThrow(NotFoundException)
+
+			expect(prisma.task.create).not.toHaveBeenCalled()
+		})
+	})
+})


### PR DESCRIPTION
## Что сделано:
- Созданы тестовые хелперы `tasks.helpers.ts`.
- Написаны unit-тесты для метода `create` в `tasks.service.spec.ts` (покрыты happy path и сценарии с ошибками доступа/отсутствия проекта).
- Создан класс `CreateTaskDto` на базе общей схемы валидации `@repo/types`.
- Реализован метод `create` в сервисе с интеграцией Prisma:
  - Проверка прав пользователя в команде.
  - Проверка привязки проекта к команде.
  - Расчет `position` по формуле `MAX(position) + 1` для конкретного `projectId` и `status`.
- Все новые тесты успешно проходят.