### PR TITLE
feat(api): реализовать пагинированный список задач проекта с фильтрацией

### DIFF
--- a/apps/api/src/tasks/dto/task-filter-query.dto.ts
+++ b/apps/api/src/tasks/dto/task-filter-query.dto.ts
@@ -1,0 +1,25 @@
+import { ApiPropertyOptional } from '@nestjs/swagger'
+import { type Priority, type TaskStatus } from '@repo/types'
+import { PaginationQueryDto } from '../../common/dto/pagination-query.dto'
+
+export class TaskFilterQueryDto extends PaginationQueryDto {
+	@ApiPropertyOptional({
+		example: 'TODO',
+		enum: ['TODO', 'BACKLOG', 'IN_PROGRESS', 'IN_REVIEW', 'DONE'],
+		description: 'Фильтр по статусу задачи',
+	})
+	status?: TaskStatus
+
+	@ApiPropertyOptional({
+		example: 'HIGH',
+		enum: ['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'],
+		description: 'Фильтр по приоритету задачи',
+	})
+	priority?: Priority
+
+	@ApiPropertyOptional({
+		example: 'user-uuid',
+		description: 'Фильтр по ID исполнителя',
+	})
+	assigneeId?: string
+}

--- a/apps/api/src/tasks/tasks.service.ts
+++ b/apps/api/src/tasks/tasks.service.ts
@@ -1,7 +1,13 @@
 import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common'
 import { TaskStatus, type TeamMember } from 'generated/prisma/client'
 import { PrismaService } from '../../prisma/prisma.service'
+import {
+	buildPaginatedResponse,
+	getPaginationPrismaParams,
+	type PaginationOptions,
+} from '../utils/pagination.util'
 import { CreateTaskDto } from './dto/create-task.dto'
+import { TaskFilterQueryDto } from './dto/task-filter-query.dto'
 
 @Injectable()
 export class TasksService {
@@ -59,5 +65,37 @@ export class TasksService {
 				position,
 			},
 		})
+	}
+
+	async findAll(
+		teamId: string,
+		projectId: string,
+		userId: string,
+		filters: Pick<TaskFilterQueryDto, 'status' | 'priority' | 'assigneeId'>,
+		pagination: PaginationOptions,
+	) {
+		await this.assertTeamMember(teamId, userId)
+		await this.findProjectOrThrow(teamId, projectId)
+
+		const where = {
+			projectId,
+			...(filters.status && { status: filters.status as never }),
+			...(filters.priority && { priority: filters.priority as never }),
+			...(filters.assigneeId && { assigneeId: filters.assigneeId }),
+		}
+
+		const { skip, take } = getPaginationPrismaParams(pagination)
+
+		const [tasks, total] = await Promise.all([
+			this.prisma.task.findMany({
+				where,
+				orderBy: [{ status: 'asc' }, { position: 'asc' }],
+				skip,
+				take,
+			}),
+			this.prisma.task.count({ where }),
+		])
+
+		return buildPaginatedResponse(tasks, pagination, total)
 	}
 }

--- a/apps/api/test/helpers/tasks.helpers.ts
+++ b/apps/api/test/helpers/tasks.helpers.ts
@@ -15,6 +15,8 @@ export function createPrismaMock() {
 		task: {
 			aggregate: vi.fn(),
 			create: vi.fn(),
+			findMany: vi.fn(),
+			count: vi.fn(),
 		},
 	} as unknown as PrismaService & {
 		teamMember: {
@@ -26,6 +28,8 @@ export function createPrismaMock() {
 		task: {
 			aggregate: ReturnType<typeof vi.fn>
 			create: ReturnType<typeof vi.fn>
+			findMany: ReturnType<typeof vi.fn>
+			count: ReturnType<typeof vi.fn>
 		}
 	}
 }

--- a/apps/api/test/unit/tasks/tasks.service.spec.ts
+++ b/apps/api/test/unit/tasks/tasks.service.spec.ts
@@ -118,4 +118,119 @@ describe('TasksService', () => {
 			expect(prisma.task.create).not.toHaveBeenCalled()
 		})
 	})
+
+	// ── findAll ───────────────────────────────────────────────────────────────
+	describe('findAll', () => {
+		const PAGINATION = { page: 1, limit: 10 }
+
+		it('должен вернуть пагинированный список задач без фильтров с дефолтной сортировкой', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.project.findUnique.mockResolvedValue(MOCK_PROJECT)
+			prisma.task.findMany.mockResolvedValue([MOCK_TASK])
+			prisma.task.count.mockResolvedValue(1)
+
+			const result = await service.findAll(TEAM_ID, PROJECT_ID, USER_ID, {}, PAGINATION)
+
+			expect(prisma.task.findMany).toHaveBeenCalledWith(
+				expect.objectContaining({
+					where: { projectId: PROJECT_ID },
+					orderBy: [{ status: 'asc' }, { position: 'asc' }],
+					skip: 0,
+					take: 10,
+				}),
+			)
+			expect(prisma.task.count).toHaveBeenCalledWith(
+				expect.objectContaining({ where: { projectId: PROJECT_ID } }),
+			)
+			expect(result).toEqual({
+				data: [MOCK_TASK],
+				meta: { page: 1, limit: 10, total: 1, totalPages: 1 },
+			})
+		})
+
+		it('должен фильтровать задачи по status', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.project.findUnique.mockResolvedValue(MOCK_PROJECT)
+			prisma.task.findMany.mockResolvedValue([MOCK_TASK])
+			prisma.task.count.mockResolvedValue(1)
+
+			await service.findAll(
+				TEAM_ID,
+				PROJECT_ID,
+				USER_ID,
+				{ status: 'TODO' as never },
+				PAGINATION,
+			)
+
+			expect(prisma.task.findMany).toHaveBeenCalledWith(
+				expect.objectContaining({
+					where: { projectId: PROJECT_ID, status: 'TODO' },
+				}),
+			)
+		})
+
+		it('должен фильтровать задачи по priority', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.project.findUnique.mockResolvedValue(MOCK_PROJECT)
+			prisma.task.findMany.mockResolvedValue([MOCK_TASK])
+			prisma.task.count.mockResolvedValue(1)
+
+			await service.findAll(
+				TEAM_ID,
+				PROJECT_ID,
+				USER_ID,
+				{ priority: 'HIGH' as never },
+				PAGINATION,
+			)
+
+			expect(prisma.task.findMany).toHaveBeenCalledWith(
+				expect.objectContaining({
+					where: { projectId: PROJECT_ID, priority: 'HIGH' },
+				}),
+			)
+		})
+
+		it('должен фильтровать задачи по assigneeId', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.project.findUnique.mockResolvedValue(MOCK_PROJECT)
+			prisma.task.findMany.mockResolvedValue([MOCK_TASK])
+			prisma.task.count.mockResolvedValue(1)
+
+			const ASSIGNEE_ID = 'assignee-uuid'
+			await service.findAll(
+				TEAM_ID,
+				PROJECT_ID,
+				USER_ID,
+				{ assigneeId: ASSIGNEE_ID },
+				PAGINATION,
+			)
+
+			expect(prisma.task.findMany).toHaveBeenCalledWith(
+				expect.objectContaining({
+					where: { projectId: PROJECT_ID, assigneeId: ASSIGNEE_ID },
+				}),
+			)
+		})
+
+		it('должен выбросить ForbiddenException если пользователь не является членом команды', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(null)
+
+			await expect(
+				service.findAll(TEAM_ID, PROJECT_ID, USER_ID, {}, PAGINATION),
+			).rejects.toThrow(ForbiddenException)
+
+			expect(prisma.task.findMany).not.toHaveBeenCalled()
+		})
+
+		it('должен выбросить NotFoundException если проект не найден', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.project.findUnique.mockResolvedValue(null)
+
+			await expect(
+				service.findAll(TEAM_ID, PROJECT_ID, USER_ID, {}, PAGINATION),
+			).rejects.toThrow(NotFoundException)
+
+			expect(prisma.task.findMany).not.toHaveBeenCalled()
+		})
+	})
 })


### PR DESCRIPTION
## Что сделано:
- Написаны unit-тесты для метода `findAll` (проверка дефолтной выдачи, сортировки и каждого фильтра в отдельности).
- Создан класс `TaskFilterQueryDto`, расширяющий базовую пагинацию проекта.
- Реализован метод `findAll` в сервисе с интеграцией Prisma:
  - Проверка прав доступа пользователя к проекту.
  - Динамическое построение объекта фильтрации (`status`, `priority`, `assigneeId`).
  - Сортировка по умолчанию: сначала по статусу, затем по позиции (`status: asc, position: asc`).
  - Применение общих утилит `getPaginationPrismaParams` и `buildPaginatedResponse`.
