### PR TITLE
feat(api): реализовать получение задачи по ID с проверкой принадлежно…

### DIFF
--- a/apps/api/src/tasks/tasks.service.ts
+++ b/apps/api/src/tasks/tasks.service.ts
@@ -98,4 +98,16 @@ export class TasksService {
 
 		return buildPaginatedResponse(tasks, pagination, total)
 	}
+
+	async findOne(teamId: string, projectId: string, taskId: string, userId: string) {
+		await this.assertTeamMember(teamId, userId)
+
+		const task = await this.prisma.task.findUnique({ where: { id: taskId } })
+
+		if (!task || task.projectId !== projectId) {
+			throw new NotFoundException('Задача не найдена в этом проекте')
+		}
+
+		return task
+	}
 }

--- a/apps/api/test/helpers/tasks.helpers.ts
+++ b/apps/api/test/helpers/tasks.helpers.ts
@@ -16,6 +16,7 @@ export function createPrismaMock() {
 			aggregate: vi.fn(),
 			create: vi.fn(),
 			findMany: vi.fn(),
+			findUnique: vi.fn(),
 			count: vi.fn(),
 		},
 	} as unknown as PrismaService & {
@@ -29,6 +30,7 @@ export function createPrismaMock() {
 			aggregate: ReturnType<typeof vi.fn>
 			create: ReturnType<typeof vi.fn>
 			findMany: ReturnType<typeof vi.fn>
+			findUnique: ReturnType<typeof vi.fn>
 			count: ReturnType<typeof vi.fn>
 		}
 	}

--- a/apps/api/test/unit/tasks/tasks.service.spec.ts
+++ b/apps/api/test/unit/tasks/tasks.service.spec.ts
@@ -233,4 +233,50 @@ describe('TasksService', () => {
 			expect(prisma.task.findMany).not.toHaveBeenCalled()
 		})
 	})
+
+	// ── findOne ───────────────────────────────────────────────────────────────
+	describe('findOne', () => {
+		it('должен вернуть задачу если она существует и принадлежит указанному проекту', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.task.findUnique.mockResolvedValue(MOCK_TASK)
+
+			const result = await service.findOne(TEAM_ID, PROJECT_ID, MOCK_TASK.id, USER_ID)
+
+			expect(prisma.task.findUnique).toHaveBeenCalledWith(
+				expect.objectContaining({ where: { id: MOCK_TASK.id } }),
+			)
+			expect(result).toEqual(MOCK_TASK)
+		})
+
+		it('должен выбросить NotFoundException если задача не найдена', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.task.findUnique.mockResolvedValue(null)
+
+			await expect(
+				service.findOne(TEAM_ID, PROJECT_ID, MOCK_TASK.id, USER_ID),
+			).rejects.toThrow(NotFoundException)
+		})
+
+		it('должен выбросить NotFoundException если задача принадлежит другому проекту (IDOR)', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.task.findUnique.mockResolvedValue({
+				...MOCK_TASK,
+				projectId: 'other-project-id',
+			})
+
+			await expect(
+				service.findOne(TEAM_ID, PROJECT_ID, MOCK_TASK.id, USER_ID),
+			).rejects.toThrow(NotFoundException)
+		})
+
+		it('должен выбросить ForbiddenException если пользователь не является членом команды', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(null)
+
+			await expect(
+				service.findOne(TEAM_ID, PROJECT_ID, MOCK_TASK.id, USER_ID),
+			).rejects.toThrow(ForbiddenException)
+
+			expect(prisma.task.findUnique).not.toHaveBeenCalled()
+		})
+	})
 })


### PR DESCRIPTION
## Что сделано:
- Написаны unit-тесты для метода `findOne` (проверка happy path, кейс отсутствия задачи и кейс обращения к задаче из чужого проекта).
- Реализована логика метода `findOne` в сервисе:
  - Проверка членства пользователя в команде.
  - Поиск задачи в БД по `id`.
  - Строгая проверка соответствия `task.projectId === projectId` для исключения несанкционированного доступа через подмену ID в URL.
  - Выброс `NotFoundException`, если задача не найдена или принадлежит другому проекту.
