### PR TITLE
feat(api): реализовать обновление задачи с проверкой прав создателя и…

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -47,6 +47,7 @@ model User {
   password        String
   createdProjects Project[]
   assignedTasks   Task[]
+  createdTasks    Task[]           @relation("CreatedTasks")
   teamMemberships TeamMember[]
   sentInvitations TeamInvitation[] @relation("SentInvitations")
   createdAt       DateTime         @default(now())
@@ -122,6 +123,8 @@ model Task {
   project     Project    @relation(fields: [projectId], references: [id], onDelete: Cascade)
   assigneeId  String?
   assignee    User?      @relation(fields: [assigneeId], references: [id])
+  createdById String
+  createdBy   User       @relation("CreatedTasks", fields: [createdById], references: [id])
   createdAt   DateTime   @default(now())
   updatedAt   DateTime   @updatedAt
 

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -125,6 +125,7 @@ async function main() {
 				status: 'DONE',
 				priority: 'HIGH',
 				projectId: project1.id,
+				createdById: user1.id,
 				assigneeId: user2.id,
 			},
 			{
@@ -133,6 +134,7 @@ async function main() {
 				status: 'IN_PROGRESS',
 				priority: 'HIGH',
 				projectId: project1.id,
+				createdById: user1.id,
 				assigneeId: user2.id,
 			},
 			{
@@ -141,6 +143,7 @@ async function main() {
 				status: 'IN_PROGRESS',
 				priority: 'MEDIUM',
 				projectId: project1.id,
+				createdById: user1.id,
 				assigneeId: user2.id,
 			},
 			{
@@ -149,6 +152,7 @@ async function main() {
 				status: 'TODO',
 				priority: 'MEDIUM',
 				projectId: project1.id,
+				createdById: user1.id,
 				assigneeId: user2.id,
 			},
 			{
@@ -157,6 +161,7 @@ async function main() {
 				status: 'TODO',
 				priority: 'LOW',
 				projectId: project1.id,
+				createdById: user1.id,
 				assigneeId: null, // Задача пока не назначена
 			},
 		],
@@ -171,6 +176,7 @@ async function main() {
 				status: 'IN_REVIEW',
 				priority: 'CRITICAL',
 				projectId: project2.id,
+				createdById: user3.id,
 				assigneeId: user3.id,
 			},
 			{
@@ -179,6 +185,7 @@ async function main() {
 				status: 'TODO',
 				priority: 'HIGH',
 				projectId: project2.id,
+				createdById: user3.id,
 				assigneeId: null,
 			},
 			{
@@ -187,6 +194,7 @@ async function main() {
 				status: 'TODO',
 				priority: 'MEDIUM',
 				projectId: project2.id,
+				createdById: user3.id,
 				assigneeId: null,
 			},
 		],

--- a/apps/api/src/tasks/dto/update-task.dto.ts
+++ b/apps/api/src/tasks/dto/update-task.dto.ts
@@ -1,0 +1,43 @@
+import { ApiPropertyOptional } from '@nestjs/swagger'
+import { type Priority, type TaskStatus, updateTaskSchema } from '@repo/types'
+import { createZodDto } from 'nestjs-zod'
+
+export class UpdateTaskDto extends createZodDto(updateTaskSchema) {
+	@ApiPropertyOptional({
+		example: 'Fix login bug',
+		description: 'Название задачи (1–255 символов)',
+	})
+	title?: string
+
+	@ApiPropertyOptional({
+		example: 'The login form breaks on mobile Safari',
+		description: 'Описание задачи (до 5000 символов)',
+	})
+	description?: string
+
+	@ApiPropertyOptional({
+		example: 'TODO',
+		enum: ['TODO', 'BACKLOG', 'IN_PROGRESS', 'IN_REVIEW', 'DONE'],
+		description: 'Статус задачи',
+	})
+	status?: TaskStatus
+
+	@ApiPropertyOptional({
+		example: 'MEDIUM',
+		enum: ['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'],
+		description: 'Приоритет задачи',
+	})
+	priority?: Priority
+
+	@ApiPropertyOptional({
+		example: 'user-uuid',
+		description: 'ID исполнителя',
+	})
+	assigneeId?: string
+
+	@ApiPropertyOptional({
+		example: '2025-12-31T23:59:59.000Z',
+		description: 'Дедлайн задачи в формате ISO 8601',
+	})
+	dueDate?: string
+}

--- a/apps/api/src/tasks/tasks.service.ts
+++ b/apps/api/src/tasks/tasks.service.ts
@@ -1,5 +1,5 @@
 import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common'
-import { TaskStatus, type TeamMember } from 'generated/prisma/client'
+import { TaskStatus, TeamRole, type TeamMember } from 'generated/prisma/client'
 import { PrismaService } from '../../prisma/prisma.service'
 import {
 	buildPaginatedResponse,
@@ -7,6 +7,7 @@ import {
 	type PaginationOptions,
 } from '../utils/pagination.util'
 import { CreateTaskDto } from './dto/create-task.dto'
+import { UpdateTaskDto } from './dto/update-task.dto'
 import { TaskFilterQueryDto } from './dto/task-filter-query.dto'
 
 @Injectable()
@@ -63,6 +64,7 @@ export class TasksService {
 				dueDate: dto.dueDate ? new Date(dto.dueDate) : undefined,
 				projectId,
 				position,
+				createdById: userId,
 			},
 		})
 	}
@@ -101,7 +103,10 @@ export class TasksService {
 
 	async findOne(teamId: string, projectId: string, taskId: string, userId: string) {
 		await this.assertTeamMember(teamId, userId)
+		return this.findTaskOrThrow(projectId, taskId)
+	}
 
+	private async findTaskOrThrow(projectId: string, taskId: string) {
 		const task = await this.prisma.task.findUnique({ where: { id: taskId } })
 
 		if (!task || task.projectId !== projectId) {
@@ -109,5 +114,36 @@ export class TasksService {
 		}
 
 		return task
+	}
+
+	async update(
+		teamId: string,
+		projectId: string,
+		taskId: string,
+		userId: string,
+		dto: UpdateTaskDto,
+	) {
+		const member = await this.assertTeamMember(teamId, userId)
+		const task = await this.findTaskOrThrow(projectId, taskId)
+
+		const isAdminOrOwner =
+			member.role === TeamRole.ADMIN || member.role === TeamRole.OWNER
+		const isCreator = task.createdById === userId
+
+		if (!isCreator && !isAdminOrOwner) {
+			throw new ForbiddenException('Недостаточно прав для выполнения этого действия')
+		}
+
+		return this.prisma.task.update({
+			where: { id: taskId },
+			data: {
+				...(dto.title !== undefined && { title: dto.title }),
+				...(dto.description !== undefined && { description: dto.description }),
+				...(dto.status !== undefined && { status: dto.status as never }),
+				...(dto.priority !== undefined && { priority: dto.priority as never }),
+				...(dto.assigneeId !== undefined && { assigneeId: dto.assigneeId }),
+				...(dto.dueDate !== undefined && { dueDate: new Date(dto.dueDate) }),
+			},
+		})
 	}
 }

--- a/apps/api/test/helpers/tasks.helpers.ts
+++ b/apps/api/test/helpers/tasks.helpers.ts
@@ -18,6 +18,7 @@ export function createPrismaMock() {
 			findMany: vi.fn(),
 			findUnique: vi.fn(),
 			count: vi.fn(),
+			update: vi.fn(),
 		},
 	} as unknown as PrismaService & {
 		teamMember: {
@@ -32,6 +33,7 @@ export function createPrismaMock() {
 			findMany: ReturnType<typeof vi.fn>
 			findUnique: ReturnType<typeof vi.fn>
 			count: ReturnType<typeof vi.fn>
+			update: ReturnType<typeof vi.fn>
 		}
 	}
 }
@@ -40,12 +42,29 @@ export function createPrismaMock() {
 
 export const PROJECT_ID = 'project-id-1'
 export const TASK_ID = 'task-id-1'
+export const OTHER_USER_ID = 'other-user-id'
 
 export const MEMBER_OWNER = {
 	id: 'member-id-1',
 	teamId: TEAM_ID,
 	userId: USER_ID,
 	role: 'OWNER' as const,
+	joinedAt: new Date(),
+}
+
+export const MEMBER_ADMIN = {
+	id: 'member-id-2',
+	teamId: TEAM_ID,
+	userId: 'admin-user-id',
+	role: 'ADMIN' as const,
+	joinedAt: new Date(),
+}
+
+export const MEMBER_PLAIN = {
+	id: 'member-id-3',
+	teamId: TEAM_ID,
+	userId: OTHER_USER_ID,
+	role: 'MEMBER' as const,
 	joinedAt: new Date(),
 }
 
@@ -69,10 +88,15 @@ export const MOCK_TASK = {
 	dueDate: null,
 	projectId: PROJECT_ID,
 	assigneeId: null,
+	createdById: USER_ID,
 	createdAt: new Date(),
 	updatedAt: new Date(),
 }
 
 export const CREATE_TASK_DTO = {
 	title: 'Fix login bug',
+}
+
+export const UPDATE_TASK_DTO = {
+	title: 'Updated title',
 }

--- a/apps/api/test/unit/tasks/tasks.service.spec.ts
+++ b/apps/api/test/unit/tasks/tasks.service.spec.ts
@@ -5,11 +5,15 @@ import { TasksService } from '../../../src/tasks/tasks.service'
 import {
 	createPrismaMock,
 	CREATE_TASK_DTO,
+	MEMBER_ADMIN,
 	MEMBER_OWNER,
+	MEMBER_PLAIN,
 	MOCK_PROJECT,
 	MOCK_TASK,
+	OTHER_USER_ID,
 	PROJECT_ID,
 	TEAM_ID,
+	UPDATE_TASK_DTO,
 	USER_ID,
 } from '../../helpers/tasks.helpers'
 
@@ -277,6 +281,130 @@ describe('TasksService', () => {
 			).rejects.toThrow(ForbiddenException)
 
 			expect(prisma.task.findUnique).not.toHaveBeenCalled()
+		})
+	})
+
+	// ── update ──────────────────────────────────────────────────────────────────
+	describe('update', () => {
+		const UPDATED_TASK = { ...MOCK_TASK, title: UPDATE_TASK_DTO.title }
+
+		it('должен обновить задачу если пользователь является её создателем (даже с ролью MEMBER)', async () => {
+			// MEMBER_PLAIN is the creator of the task (createdById === OTHER_USER_ID)
+			const taskCreatedByPlain = { ...MOCK_TASK, createdById: OTHER_USER_ID }
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_PLAIN)
+			prisma.task.findUnique.mockResolvedValue(taskCreatedByPlain)
+			prisma.task.update.mockResolvedValue({
+				...taskCreatedByPlain,
+				title: UPDATE_TASK_DTO.title,
+			})
+
+			const result = await service.update(
+				TEAM_ID,
+				PROJECT_ID,
+				MOCK_TASK.id,
+				OTHER_USER_ID,
+				UPDATE_TASK_DTO as never,
+			)
+
+			expect(prisma.task.update).toHaveBeenCalledWith(
+				expect.objectContaining({
+					where: { id: MOCK_TASK.id },
+					data: expect.objectContaining({ title: UPDATE_TASK_DTO.title }),
+				}),
+			)
+			expect(result.title).toBe(UPDATE_TASK_DTO.title)
+		})
+
+		it('должен обновить задачу если пользователь является OWNER (даже если он не создавал задачу)', async () => {
+			// MEMBER_OWNER.userId === USER_ID, but MOCK_TASK.createdById === USER_ID too — use a task created by someone else
+			const taskByOther = { ...MOCK_TASK, createdById: OTHER_USER_ID }
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.task.findUnique.mockResolvedValue(taskByOther)
+			prisma.task.update.mockResolvedValue(UPDATED_TASK)
+
+			const result = await service.update(
+				TEAM_ID,
+				PROJECT_ID,
+				MOCK_TASK.id,
+				USER_ID,
+				UPDATE_TASK_DTO as never,
+			)
+
+			expect(prisma.task.update).toHaveBeenCalled()
+			expect(result.title).toBe(UPDATE_TASK_DTO.title)
+		})
+
+		it('должен обновить задачу если пользователь является ADMIN (даже если он не создавал задачу)', async () => {
+			const taskByOther = { ...MOCK_TASK, createdById: OTHER_USER_ID }
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_ADMIN)
+			prisma.task.findUnique.mockResolvedValue(taskByOther)
+			prisma.task.update.mockResolvedValue(UPDATED_TASK)
+
+			const result = await service.update(
+				TEAM_ID,
+				PROJECT_ID,
+				MOCK_TASK.id,
+				MEMBER_ADMIN.userId,
+				UPDATE_TASK_DTO as never,
+			)
+
+			expect(prisma.task.update).toHaveBeenCalled()
+			expect(result.title).toBe(UPDATE_TASK_DTO.title)
+		})
+
+		it('должен выбросить ForbiddenException если MEMBER пытается обновить чужую задачу', async () => {
+			// MEMBER_PLAIN is not the creator (task.createdById === USER_ID, not OTHER_USER_ID)
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_PLAIN)
+			prisma.task.findUnique.mockResolvedValue(MOCK_TASK) // createdById === USER_ID
+
+			await expect(
+				service.update(
+					TEAM_ID,
+					PROJECT_ID,
+					MOCK_TASK.id,
+					OTHER_USER_ID,
+					UPDATE_TASK_DTO as never,
+				),
+			).rejects.toThrow(ForbiddenException)
+
+			expect(prisma.task.update).not.toHaveBeenCalled()
+		})
+
+		it('должен выбросить NotFoundException если задача не найдена или не принадлежит проекту', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.task.findUnique.mockResolvedValue(null)
+
+			await expect(
+				service.update(
+					TEAM_ID,
+					PROJECT_ID,
+					MOCK_TASK.id,
+					USER_ID,
+					UPDATE_TASK_DTO as never,
+				),
+			).rejects.toThrow(NotFoundException)
+
+			expect(prisma.task.update).not.toHaveBeenCalled()
+		})
+
+		it('должен выбросить NotFoundException если задача принадлежит другому проекту (IDOR)', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.task.findUnique.mockResolvedValue({
+				...MOCK_TASK,
+				projectId: 'other-project-id',
+			})
+
+			await expect(
+				service.update(
+					TEAM_ID,
+					PROJECT_ID,
+					MOCK_TASK.id,
+					USER_ID,
+					UPDATE_TASK_DTO as never,
+				),
+			).rejects.toThrow(NotFoundException)
+
+			expect(prisma.task.update).not.toHaveBeenCalled()
 		})
 	})
 })


### PR DESCRIPTION
## Что сделано:
- Создан класс `UpdateTaskDto` на базе частичной схемы валидации `@repo/types`.
- Написаны unit-тесты для метода `update` (проверка успешного обновления автором, проверка прав OWNER/ADMIN, тест на ошибку 403 для стороннего MEMBER и тест на 404).
- Реализована логика метода `update` в сервисе:
  - Поиск задачи и валидация её принадлежности текущему проекту.
  - Извлечение роли пользователя в команде.
  - Проверка условий: `task.createdById === userId || ['OWNER', 'ADMIN'].includes(member.role)`.
  - Вызов `prisma.task.update` для сохранения изменений.