### PR TITLE
feat(api): реализовать удаление задачи с ограничением прав для OWNER …

### DIFF
--- a/apps/api/src/tasks/tasks.service.ts
+++ b/apps/api/src/tasks/tasks.service.ts
@@ -146,4 +146,21 @@ export class TasksService {
 			},
 		})
 	}
+
+	async remove(teamId: string, projectId: string, taskId: string, userId: string) {
+		const member = await this.assertTeamMember(teamId, userId)
+
+		const isAdminOrOwner =
+			member.role === TeamRole.ADMIN || member.role === TeamRole.OWNER
+
+		if (!isAdminOrOwner) {
+			throw new ForbiddenException('Недостаточно прав для выполнения этого действия')
+		}
+
+		await this.findTaskOrThrow(projectId, taskId)
+
+		await this.prisma.task.delete({ where: { id: taskId } })
+
+		return { message: 'Задача успешно удалена', success: true }
+	}
 }

--- a/apps/api/test/helpers/tasks.helpers.ts
+++ b/apps/api/test/helpers/tasks.helpers.ts
@@ -19,6 +19,7 @@ export function createPrismaMock() {
 			findUnique: vi.fn(),
 			count: vi.fn(),
 			update: vi.fn(),
+			delete: vi.fn(),
 		},
 	} as unknown as PrismaService & {
 		teamMember: {
@@ -34,6 +35,7 @@ export function createPrismaMock() {
 			findUnique: ReturnType<typeof vi.fn>
 			count: ReturnType<typeof vi.fn>
 			update: ReturnType<typeof vi.fn>
+			delete: ReturnType<typeof vi.fn>
 		}
 	}
 }

--- a/apps/api/test/unit/tasks/tasks.service.spec.ts
+++ b/apps/api/test/unit/tasks/tasks.service.spec.ts
@@ -407,4 +407,79 @@ describe('TasksService', () => {
 			expect(prisma.task.update).not.toHaveBeenCalled()
 		})
 	})
+
+	// ── remove ──────────────────────────────────────────────────────────────────
+	describe('remove', () => {
+		it('должен удалить задачу если пользователь является OWNER', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.task.findUnique.mockResolvedValue(MOCK_TASK)
+			prisma.task.delete.mockResolvedValue(MOCK_TASK)
+
+			await service.remove(TEAM_ID, PROJECT_ID, MOCK_TASK.id, USER_ID)
+
+			expect(prisma.task.delete).toHaveBeenCalledWith(
+				expect.objectContaining({ where: { id: MOCK_TASK.id } }),
+			)
+		})
+
+		it('должен удалить задачу если пользователь является ADMIN', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_ADMIN)
+			prisma.task.findUnique.mockResolvedValue(MOCK_TASK)
+			prisma.task.delete.mockResolvedValue(MOCK_TASK)
+
+			await service.remove(TEAM_ID, PROJECT_ID, MOCK_TASK.id, MEMBER_ADMIN.userId)
+
+			expect(prisma.task.delete).toHaveBeenCalledWith(
+				expect.objectContaining({ where: { id: MOCK_TASK.id } }),
+			)
+		})
+
+		it('должен выбросить ForbiddenException если пользователь является MEMBER (не создатель)', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_PLAIN)
+
+			await expect(
+				service.remove(TEAM_ID, PROJECT_ID, MOCK_TASK.id, OTHER_USER_ID),
+			).rejects.toThrow(ForbiddenException)
+
+			expect(prisma.task.delete).not.toHaveBeenCalled()
+		})
+
+		it('должен выбросить ForbiddenException даже если MEMBER является создателем задачи', async () => {
+			// Задача создана тем же пользователем, но его роль — MEMBER
+			const taskCreatedByPlain = { ...MOCK_TASK, createdById: OTHER_USER_ID }
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_PLAIN)
+			prisma.task.findUnique.mockResolvedValue(taskCreatedByPlain)
+
+			await expect(
+				service.remove(TEAM_ID, PROJECT_ID, MOCK_TASK.id, OTHER_USER_ID),
+			).rejects.toThrow(ForbiddenException)
+
+			expect(prisma.task.delete).not.toHaveBeenCalled()
+		})
+
+		it('должен выбросить NotFoundException если задача не найдена или не принадлежит проекту', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.task.findUnique.mockResolvedValue(null)
+
+			await expect(
+				service.remove(TEAM_ID, PROJECT_ID, MOCK_TASK.id, USER_ID),
+			).rejects.toThrow(NotFoundException)
+
+			expect(prisma.task.delete).not.toHaveBeenCalled()
+		})
+
+		it('должен выбросить NotFoundException если задача принадлежит другому проекту (IDOR)', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.task.findUnique.mockResolvedValue({
+				...MOCK_TASK,
+				projectId: 'other-project-id',
+			})
+
+			await expect(
+				service.remove(TEAM_ID, PROJECT_ID, MOCK_TASK.id, USER_ID),
+			).rejects.toThrow(NotFoundException)
+
+			expect(prisma.task.delete).not.toHaveBeenCalled()
+		})
+	})
 })


### PR DESCRIPTION
## Что сделано:
- Написаны unit-тесты для метода `remove` (проверка успешного удаления ролями OWNER/ADMIN, тесты на ошибку 403 для обычного MEMBER и для автора задачи без админ-прав, а также тест на ошибку 404).
- Реализована логика метода `remove` в сервисе:
  - Проверка роли пользователя (`member.role === 'OWNER' || member.role === 'ADMIN'`).
  - Проверка существования задачи и её валидности в контексте текущего проекта.
  - Вызов `prisma.task.delete` для удаления записи из базы данных.