### PR TITLE
feature(web):Типы и API-сервис для задач

### DIFF
--- a/apps/web/shared/api/use-tasks.ts
+++ b/apps/web/shared/api/use-tasks.ts
@@ -1,0 +1,109 @@
+import {
+	keepPreviousData,
+	useMutation,
+	useQuery,
+	useQueryClient,
+} from '@tanstack/react-query'
+
+import type {
+	CreateTask,
+	PaginatedResponse,
+	Task,
+	TaskFilterParams,
+	UpdateTask,
+} from '@repo/types'
+
+import { tasksService } from '@/shared/lib/api/tasks-service'
+import type { ApiError } from '@/shared/lib/api/types'
+
+export const tasksKeys = {
+	all: ['tasks'] as const,
+	lists: () => [...tasksKeys.all, 'list'] as const,
+	projectLists: (teamId: string, projectId: string) =>
+		[...tasksKeys.lists(), teamId, projectId] as const,
+	list: (teamId: string, projectId: string, params?: TaskFilterParams) =>
+		[...tasksKeys.projectLists(teamId, projectId), params] as const,
+	details: () => [...tasksKeys.all, 'detail'] as const,
+	detail: (teamId: string, projectId: string, taskId: string) =>
+		[...tasksKeys.details(), teamId, projectId, taskId] as const,
+} as const
+
+export const useTasksList = (
+	teamId: string,
+	projectId: string,
+	params?: TaskFilterParams,
+) => {
+	return useQuery<PaginatedResponse<Task>>({
+		queryKey: tasksKeys.list(teamId, projectId, params),
+		queryFn: () => tasksService.getAll(teamId, projectId, params),
+		enabled: Boolean(teamId) && Boolean(projectId),
+		placeholderData: keepPreviousData,
+	})
+}
+
+export const useTaskDetail = (teamId: string, projectId: string, taskId: string) => {
+	return useQuery<Task>({
+		queryKey: tasksKeys.detail(teamId, projectId, taskId),
+		queryFn: () => tasksService.getById(teamId, projectId, taskId),
+		enabled: Boolean(teamId) && Boolean(projectId) && Boolean(taskId),
+	})
+}
+
+export const useCreateTask = () => {
+	const queryClient = useQueryClient()
+
+	return useMutation<
+		Task,
+		ApiError,
+		{ teamId: string; projectId: string; data: CreateTask }
+	>({
+		mutationFn: ({ teamId, projectId, data }) =>
+			tasksService.create(teamId, projectId, data),
+		onSuccess: (task, { teamId, projectId }) => {
+			queryClient.setQueryData(tasksKeys.detail(teamId, projectId, task.id), task)
+			queryClient.invalidateQueries({
+				queryKey: tasksKeys.projectLists(teamId, projectId),
+			})
+		},
+	})
+}
+
+export const useUpdateTask = () => {
+	const queryClient = useQueryClient()
+
+	return useMutation<
+		Task,
+		ApiError,
+		{ teamId: string; projectId: string; taskId: string; data: UpdateTask }
+	>({
+		mutationFn: ({ teamId, projectId, taskId, data }) =>
+			tasksService.update(teamId, projectId, taskId, data),
+		onSuccess: (task, { teamId, projectId, taskId }) => {
+			queryClient.setQueryData(tasksKeys.detail(teamId, projectId, taskId), task)
+			queryClient.invalidateQueries({
+				queryKey: tasksKeys.projectLists(teamId, projectId),
+			})
+		},
+	})
+}
+
+export const useDeleteTask = () => {
+	const queryClient = useQueryClient()
+
+	return useMutation<
+		void,
+		ApiError,
+		{ teamId: string; projectId: string; taskId: string }
+	>({
+		mutationFn: ({ teamId, projectId, taskId }) =>
+			tasksService.delete(teamId, projectId, taskId),
+		onSuccess: (_, { teamId, projectId, taskId }) => {
+			queryClient.invalidateQueries({
+				queryKey: tasksKeys.projectLists(teamId, projectId),
+			})
+			queryClient.removeQueries({
+				queryKey: tasksKeys.detail(teamId, projectId, taskId),
+			})
+		},
+	})
+}

--- a/apps/web/shared/lib/api/tasks-service.ts
+++ b/apps/web/shared/lib/api/tasks-service.ts
@@ -1,0 +1,192 @@
+import type {
+	CreateTask,
+	PaginatedResponse,
+	Task,
+	TaskFilterParams,
+	UpdateTask,
+} from '@repo/types'
+
+import { client } from './client'
+
+const buildTasksEndpoint = (teamId: string, projectId: string) =>
+	`/teams/${teamId}/projects/${projectId}/tasks`
+
+const buildTaskEndpoint = (teamId: string, projectId: string, taskId: string) =>
+	`/teams/${teamId}/projects/${projectId}/tasks/${taskId}`
+
+// Mock data — remove together with USE_MOCK when backend controller exposes routes
+const USE_MOCK = true
+
+const MOCK_TASKS: Task[] = [
+	{
+		id: 'mock-task-1',
+		title: 'Настроить CI/CD pipeline',
+		description: 'Настроить автоматическую сборку и деплой через GitHub Actions',
+		type: 'EPIC',
+		status: 'IN_PROGRESS',
+		priority: 'HIGH',
+		position: 1,
+		projectId: 'mock-project-1',
+		assigneeId: null,
+		dueDate: null,
+		createdAt: new Date().toISOString(),
+		updatedAt: new Date().toISOString(),
+	},
+	{
+		id: 'mock-task-2',
+		title: 'Реализовать авторизацию пользователя',
+		description: null,
+		type: 'STORY',
+		status: 'DONE',
+		priority: 'CRITICAL',
+		position: 1,
+		projectId: 'mock-project-1',
+		assigneeId: null,
+		dueDate: '2025-12-31T23:59:59.000Z',
+		createdAt: new Date().toISOString(),
+		updatedAt: new Date().toISOString(),
+	},
+	{
+		id: 'mock-task-3',
+		title: 'Исправить баг с токеном обновления',
+		description: 'Refresh-токен не сбрасывается при выходе из аккаунта',
+		type: 'BUG',
+		status: 'TODO',
+		priority: 'MEDIUM',
+		position: 2,
+		projectId: 'mock-project-1',
+		assigneeId: null,
+		dueDate: null,
+		createdAt: new Date().toISOString(),
+		updatedAt: new Date().toISOString(),
+	},
+	{
+		id: 'mock-task-4',
+		title: 'Покрыть тестами TasksService',
+		description: null,
+		type: 'TECH_DEBT',
+		status: 'BACKLOG',
+		priority: 'LOW',
+		position: 3,
+		projectId: 'mock-project-1',
+		assigneeId: null,
+		dueDate: null,
+		createdAt: new Date().toISOString(),
+		updatedAt: new Date().toISOString(),
+	},
+	{
+		id: 'mock-task-5',
+		title: 'Добавить пагинацию в список задач',
+		description: null,
+		type: 'TASK',
+		status: 'IN_REVIEW',
+		priority: 'MEDIUM',
+		position: 4,
+		projectId: 'mock-project-1',
+		assigneeId: null,
+		dueDate: null,
+		createdAt: new Date().toISOString(),
+		updatedAt: new Date().toISOString(),
+	},
+]
+
+const applyFilters = (tasks: Task[], projectId: string, params?: TaskFilterParams) =>
+	tasks.filter((task) => {
+		if (task.projectId !== projectId) return false
+		if (params?.status && task.status !== params.status) return false
+		if (params?.priority && task.priority !== params.priority) return false
+		if (params?.assigneeId && task.assigneeId !== params.assigneeId) return false
+		return true
+	})
+
+export const tasksService = {
+	getAll: async (
+		teamId: string,
+		projectId: string,
+		params?: TaskFilterParams,
+	): Promise<PaginatedResponse<Task>> => {
+		if (USE_MOCK) {
+			const tasks = applyFilters(MOCK_TASKS, projectId, params)
+			return {
+				data: tasks,
+				meta: { page: 1, limit: 20, total: tasks.length, totalPages: 1 },
+			}
+		}
+		const response = await client.get<PaginatedResponse<Task>>(
+			buildTasksEndpoint(teamId, projectId),
+			{ params },
+		)
+		return response.data
+	},
+
+	getById: async (teamId: string, projectId: string, taskId: string): Promise<Task> => {
+		if (USE_MOCK) {
+			const task = MOCK_TASKS.find((t) => t.id === taskId)
+			if (!task) return Promise.reject(new Error('Task not found'))
+			return task
+		}
+		const response = await client.get<Task>(buildTaskEndpoint(teamId, projectId, taskId))
+		return response.data
+	},
+
+	create: async (teamId: string, projectId: string, data: CreateTask): Promise<Task> => {
+		if (USE_MOCK) {
+			const newTask: Task = {
+				id: `mock-task-${Date.now()}`,
+				title: data.title,
+				description: data.description ?? null,
+				type: data.type,
+				status: data.status ?? 'TODO',
+				priority: data.priority ?? 'MEDIUM',
+				position: MOCK_TASKS.length + 1,
+				projectId,
+				assigneeId: data.assigneeId ?? null,
+				dueDate: data.dueDate ?? null,
+				createdAt: new Date().toISOString(),
+				updatedAt: new Date().toISOString(),
+			}
+			MOCK_TASKS.push(newTask)
+			return newTask
+		}
+		const response = await client.post<Task>(buildTasksEndpoint(teamId, projectId), data)
+		return response.data
+	},
+
+	update: async (
+		teamId: string,
+		projectId: string,
+		taskId: string,
+		data: UpdateTask,
+	): Promise<Task> => {
+		if (USE_MOCK) {
+			const index = MOCK_TASKS.findIndex((t) => t.id === taskId)
+			const existing = MOCK_TASKS[index]
+			if (index === -1 || !existing) return Promise.reject(new Error('Task not found'))
+			const updated: Task = {
+				...existing,
+				...data,
+				description:
+					data.description !== undefined
+						? (data.description ?? null)
+						: existing.description,
+				updatedAt: new Date().toISOString(),
+			}
+			MOCK_TASKS[index] = updated
+			return updated
+		}
+		const response = await client.patch<Task>(
+			buildTaskEndpoint(teamId, projectId, taskId),
+			data,
+		)
+		return response.data
+	},
+
+	delete: async (teamId: string, projectId: string, taskId: string): Promise<void> => {
+		if (USE_MOCK) {
+			const index = MOCK_TASKS.findIndex((t) => t.id === taskId)
+			if (index !== -1) MOCK_TASKS.splice(index, 1)
+			return
+		}
+		await client.delete(buildTaskEndpoint(teamId, projectId, taskId))
+	},
+}

--- a/apps/web/shared/lib/api/tasks-service.ts
+++ b/apps/web/shared/lib/api/tasks-service.ts
@@ -14,106 +14,12 @@ const buildTasksEndpoint = (teamId: string, projectId: string) =>
 const buildTaskEndpoint = (teamId: string, projectId: string, taskId: string) =>
 	`/teams/${teamId}/projects/${projectId}/tasks/${taskId}`
 
-// Mock data — remove together with USE_MOCK when backend controller exposes routes
-const USE_MOCK = true
-
-let mockTaskIdCounter = 5
-
-const MOCK_TASKS: Task[] = [
-	{
-		id: 'mock-task-1',
-		title: 'Настроить CI/CD pipeline',
-		description: 'Настроить автоматическую сборку и деплой через GitHub Actions',
-		type: 'EPIC',
-		status: 'IN_PROGRESS',
-		priority: 'HIGH',
-		position: 1,
-		projectId: 'mock-project-1',
-		assigneeId: null,
-		dueDate: null,
-		createdAt: new Date().toISOString(),
-		updatedAt: new Date().toISOString(),
-	},
-	{
-		id: 'mock-task-2',
-		title: 'Реализовать авторизацию пользователя',
-		description: null,
-		type: 'STORY',
-		status: 'DONE',
-		priority: 'CRITICAL',
-		position: 1,
-		projectId: 'mock-project-1',
-		assigneeId: null,
-		dueDate: '2025-12-31T23:59:59.000Z',
-		createdAt: new Date().toISOString(),
-		updatedAt: new Date().toISOString(),
-	},
-	{
-		id: 'mock-task-3',
-		title: 'Исправить баг с токеном обновления',
-		description: 'Refresh-токен не сбрасывается при выходе из аккаунта',
-		type: 'BUG',
-		status: 'TODO',
-		priority: 'MEDIUM',
-		position: 2,
-		projectId: 'mock-project-1',
-		assigneeId: null,
-		dueDate: null,
-		createdAt: new Date().toISOString(),
-		updatedAt: new Date().toISOString(),
-	},
-	{
-		id: 'mock-task-4',
-		title: 'Покрыть тестами TasksService',
-		description: null,
-		type: 'TECH_DEBT',
-		status: 'BACKLOG',
-		priority: 'LOW',
-		position: 3,
-		projectId: 'mock-project-1',
-		assigneeId: null,
-		dueDate: null,
-		createdAt: new Date().toISOString(),
-		updatedAt: new Date().toISOString(),
-	},
-	{
-		id: 'mock-task-5',
-		title: 'Добавить пагинацию в список задач',
-		description: null,
-		type: 'TASK',
-		status: 'IN_REVIEW',
-		priority: 'MEDIUM',
-		position: 4,
-		projectId: 'mock-project-1',
-		assigneeId: null,
-		dueDate: null,
-		createdAt: new Date().toISOString(),
-		updatedAt: new Date().toISOString(),
-	},
-]
-
-const applyFilters = (tasks: Task[], projectId: string, params?: TaskFilterParams) =>
-	tasks.filter((task) => {
-		if (task.projectId !== projectId) return false
-		if (params?.status && task.status !== params.status) return false
-		if (params?.priority && task.priority !== params.priority) return false
-		if (params?.assigneeId && task.assigneeId !== params.assigneeId) return false
-		return true
-	})
-
 export const tasksService = {
 	getAll: async (
 		teamId: string,
 		projectId: string,
 		params?: TaskFilterParams,
 	): Promise<PaginatedResponse<Task>> => {
-		if (USE_MOCK) {
-			const tasks = applyFilters(MOCK_TASKS, projectId, params)
-			return {
-				data: tasks,
-				meta: { page: 1, limit: 20, total: tasks.length, totalPages: 1 },
-			}
-		}
 		const response = await client.get<PaginatedResponse<Task>>(
 			buildTasksEndpoint(teamId, projectId),
 			{ params },
@@ -122,34 +28,11 @@ export const tasksService = {
 	},
 
 	getById: async (teamId: string, projectId: string, taskId: string): Promise<Task> => {
-		if (USE_MOCK) {
-			const task = MOCK_TASKS.find((t) => t.id === taskId)
-			if (!task) return Promise.reject(new Error('Task not found'))
-			return task
-		}
 		const response = await client.get<Task>(buildTaskEndpoint(teamId, projectId, taskId))
 		return response.data
 	},
 
 	create: async (teamId: string, projectId: string, data: CreateTask): Promise<Task> => {
-		if (USE_MOCK) {
-			const newTask: Task = {
-				id: `mock-task-${++mockTaskIdCounter}`,
-				title: data.title,
-				description: data.description ?? null,
-				type: data.type,
-				status: data.status ?? 'TODO',
-				priority: data.priority ?? 'MEDIUM',
-				position: MOCK_TASKS.length + 1,
-				projectId,
-				assigneeId: data.assigneeId ?? null,
-				dueDate: data.dueDate ?? null,
-				createdAt: new Date().toISOString(),
-				updatedAt: new Date().toISOString(),
-			}
-			MOCK_TASKS.push(newTask)
-			return newTask
-		}
 		const response = await client.post<Task>(buildTasksEndpoint(teamId, projectId), data)
 		return response.data
 	},
@@ -160,22 +43,6 @@ export const tasksService = {
 		taskId: string,
 		data: UpdateTask,
 	): Promise<Task> => {
-		if (USE_MOCK) {
-			const index = MOCK_TASKS.findIndex((t) => t.id === taskId)
-			const existing = MOCK_TASKS[index]
-			if (index === -1 || !existing) return Promise.reject(new Error('Task not found'))
-			const updated: Task = {
-				...existing,
-				...data,
-				description:
-					data.description !== undefined
-						? (data.description ?? null)
-						: existing.description,
-				updatedAt: new Date().toISOString(),
-			}
-			MOCK_TASKS[index] = updated
-			return updated
-		}
 		const response = await client.patch<Task>(
 			buildTaskEndpoint(teamId, projectId, taskId),
 			data,
@@ -184,11 +51,6 @@ export const tasksService = {
 	},
 
 	delete: async (teamId: string, projectId: string, taskId: string): Promise<void> => {
-		if (USE_MOCK) {
-			const index = MOCK_TASKS.findIndex((t) => t.id === taskId)
-			if (index !== -1) MOCK_TASKS.splice(index, 1)
-			return
-		}
 		await client.delete(buildTaskEndpoint(teamId, projectId, taskId))
 	},
 }

--- a/apps/web/shared/lib/api/tasks-service.ts
+++ b/apps/web/shared/lib/api/tasks-service.ts
@@ -17,6 +17,8 @@ const buildTaskEndpoint = (teamId: string, projectId: string, taskId: string) =>
 // Mock data — remove together with USE_MOCK when backend controller exposes routes
 const USE_MOCK = true
 
+let mockTaskIdCounter = 5
+
 const MOCK_TASKS: Task[] = [
 	{
 		id: 'mock-task-1',
@@ -132,7 +134,7 @@ export const tasksService = {
 	create: async (teamId: string, projectId: string, data: CreateTask): Promise<Task> => {
 		if (USE_MOCK) {
 			const newTask: Task = {
-				id: `mock-task-${Date.now()}`,
+				id: `mock-task-${++mockTaskIdCounter}`,
 				title: data.title,
 				description: data.description ?? null,
 				type: data.type,

--- a/apps/web/test/mocks/api/tasks-service.mock.ts
+++ b/apps/web/test/mocks/api/tasks-service.mock.ts
@@ -1,0 +1,29 @@
+import { vi, type MockedFunction } from 'vitest'
+
+type TasksService = typeof import('@/shared/lib/api/tasks-service').tasksService
+
+type MockedTasksService = {
+	getAll: MockedFunction<TasksService['getAll']>
+	getById: MockedFunction<TasksService['getById']>
+	create: MockedFunction<TasksService['create']>
+	update: MockedFunction<TasksService['update']>
+	delete: MockedFunction<TasksService['delete']>
+}
+
+export const tasksServiceMock: MockedTasksService = {
+	getAll: vi.fn<TasksService['getAll']>(),
+	getById: vi.fn<TasksService['getById']>(),
+	create: vi.fn<TasksService['create']>(),
+	update: vi.fn<TasksService['update']>(),
+	delete: vi.fn<TasksService['delete']>(),
+}
+
+export function resetTasksServiceMock() {
+	for (const mockFn of Object.values(tasksServiceMock)) {
+		mockFn.mockReset()
+	}
+}
+
+vi.mock('@/shared/lib/api/tasks-service', () => ({
+	tasksService: tasksServiceMock,
+}))

--- a/apps/web/test/mocks/api/tasks.fixtures.ts
+++ b/apps/web/test/mocks/api/tasks.fixtures.ts
@@ -1,0 +1,19 @@
+import type { Task } from '@repo/types'
+
+export function createTaskFixture(overrides?: Partial<Task>): Task {
+	return {
+		id: 'task-1',
+		title: 'Test Task',
+		description: null,
+		type: 'TASK',
+		status: 'TODO',
+		priority: 'MEDIUM',
+		position: 1,
+		projectId: 'project-1',
+		assigneeId: null,
+		dueDate: null,
+		createdAt: '2026-01-01T00:00:00.000Z',
+		updatedAt: '2026-01-01T00:00:00.000Z',
+		...overrides,
+	}
+}

--- a/apps/web/test/unit/shared/api/tasks-keys.spec.ts
+++ b/apps/web/test/unit/shared/api/tasks-keys.spec.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+
+import { tasksKeys } from '@/shared/api/use-tasks'
+
+describe('tasksKeys', () => {
+	it('all', () => {
+		expect(tasksKeys.all).toEqual(['tasks'])
+	})
+
+	it('lists', () => {
+		expect(tasksKeys.lists()).toEqual(['tasks', 'list'])
+	})
+
+	it('projectLists', () => {
+		expect(tasksKeys.projectLists('team-1', 'project-1')).toEqual([
+			'tasks',
+			'list',
+			'team-1',
+			'project-1',
+		])
+	})
+
+	it('list без параметров', () => {
+		expect(tasksKeys.list('team-1', 'project-1')).toEqual([
+			'tasks',
+			'list',
+			'team-1',
+			'project-1',
+			undefined,
+		])
+	})
+
+	it('list с параметрами фильтрации', () => {
+		expect(tasksKeys.list('team-1', 'project-1', { status: 'TODO', page: 2 })).toEqual([
+			'tasks',
+			'list',
+			'team-1',
+			'project-1',
+			{ status: 'TODO', page: 2 },
+		])
+	})
+
+	it('details', () => {
+		expect(tasksKeys.details()).toEqual(['tasks', 'detail'])
+	})
+
+	it('detail', () => {
+		expect(tasksKeys.detail('team-1', 'project-1', 'task-1')).toEqual([
+			'tasks',
+			'detail',
+			'team-1',
+			'project-1',
+			'task-1',
+		])
+	})
+
+	it('list разных projectId не совпадают', () => {
+		expect(tasksKeys.list('team-1', 'project-1')).not.toEqual(
+			tasksKeys.list('team-1', 'project-2'),
+		)
+	})
+
+	it('list разных teamId не совпадают', () => {
+		expect(tasksKeys.list('team-1', 'project-1')).not.toEqual(
+			tasksKeys.list('team-2', 'project-1'),
+		)
+	})
+
+	it('detail разных taskId не совпадают', () => {
+		expect(tasksKeys.detail('team-1', 'project-1', 'task-1')).not.toEqual(
+			tasksKeys.detail('team-1', 'project-1', 'task-2'),
+		)
+	})
+
+	it('все ключи начинаются с "tasks"', () => {
+		const keys = [
+			tasksKeys.all,
+			tasksKeys.lists(),
+			tasksKeys.projectLists('team-1', 'project-1'),
+			tasksKeys.list('team-1', 'project-1'),
+			tasksKeys.details(),
+			tasksKeys.detail('team-1', 'project-1', 'task-1'),
+		]
+
+		keys.forEach((key) => {
+			expect(key[0]).toBe('tasks')
+		})
+	})
+})

--- a/apps/web/test/unit/shared/api/use-tasks.spec.tsx
+++ b/apps/web/test/unit/shared/api/use-tasks.spec.tsx
@@ -1,0 +1,266 @@
+import '@/test/mocks/api/tasks-service.mock'
+
+import {
+	resetTasksServiceMock,
+	tasksServiceMock,
+} from '@/test/mocks/api/tasks-service.mock'
+import { createTaskFixture } from '@/test/mocks/api/tasks.fixtures'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+	tasksKeys,
+	useCreateTask,
+	useDeleteTask,
+	useTaskDetail,
+	useTasksList,
+	useUpdateTask,
+} from '@/shared/api/use-tasks'
+
+describe('use-tasks hooks', () => {
+	let queryClient: QueryClient
+
+	const createWrapper = () => {
+		queryClient = new QueryClient({
+			defaultOptions: {
+				queries: { retry: false },
+				mutations: { retry: false },
+			},
+		})
+
+		const Wrapper = ({ children }: React.PropsWithChildren) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		)
+		Wrapper.displayName = 'UseTasksQueryClientWrapper'
+
+		return Wrapper
+	}
+
+	beforeEach(() => {
+		resetTasksServiceMock()
+	})
+
+	describe('useTasksList', () => {
+		it('запрашивает список задач по teamId и projectId', async () => {
+			const tasks = [
+				createTaskFixture({ id: 'task-1', title: 'Task 1' }),
+				createTaskFixture({ id: 'task-2', title: 'Task 2' }),
+			]
+			const paginatedResponse = {
+				data: tasks,
+				meta: { page: 1, limit: 20, total: 2, totalPages: 1 },
+			}
+
+			tasksServiceMock.getAll.mockResolvedValue(paginatedResponse)
+
+			const { result } = renderHook(() => useTasksList('team-1', 'project-1'), {
+				wrapper: createWrapper(),
+			})
+
+			await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+			expect(tasksServiceMock.getAll).toHaveBeenCalledWith(
+				'team-1',
+				'project-1',
+				undefined,
+			)
+			expect(result.current.data).toEqual(paginatedResponse)
+		})
+
+		it('передаёт параметры фильтрации в сервис', async () => {
+			const paginatedResponse = {
+				data: [createTaskFixture({ status: 'TODO' })],
+				meta: { page: 1, limit: 20, total: 1, totalPages: 1 },
+			}
+			tasksServiceMock.getAll.mockResolvedValue(paginatedResponse)
+
+			const { result } = renderHook(
+				() => useTasksList('team-1', 'project-1', { status: 'TODO' }),
+				{ wrapper: createWrapper() },
+			)
+
+			await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+			expect(tasksServiceMock.getAll).toHaveBeenCalledWith('team-1', 'project-1', {
+				status: 'TODO',
+			})
+		})
+
+		it('не делает запрос, если teamId пустой', () => {
+			const { result } = renderHook(() => useTasksList('', 'project-1'), {
+				wrapper: createWrapper(),
+			})
+
+			expect(tasksServiceMock.getAll).not.toHaveBeenCalled()
+			expect(result.current.fetchStatus).toBe('idle')
+		})
+
+		it('не делает запрос, если projectId пустой', () => {
+			const { result } = renderHook(() => useTasksList('team-1', ''), {
+				wrapper: createWrapper(),
+			})
+
+			expect(tasksServiceMock.getAll).not.toHaveBeenCalled()
+			expect(result.current.fetchStatus).toBe('idle')
+		})
+	})
+
+	describe('useTaskDetail', () => {
+		it('запрашивает задачу по teamId, projectId и taskId', async () => {
+			const task = createTaskFixture({ id: 'task-1' })
+			tasksServiceMock.getById.mockResolvedValue(task)
+
+			const { result } = renderHook(
+				() => useTaskDetail('team-1', 'project-1', 'task-1'),
+				{ wrapper: createWrapper() },
+			)
+
+			await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+			expect(tasksServiceMock.getById).toHaveBeenCalledWith(
+				'team-1',
+				'project-1',
+				'task-1',
+			)
+			expect(result.current.data).toEqual(task)
+		})
+
+		it('не делает запрос, если taskId пустой', () => {
+			const { result } = renderHook(() => useTaskDetail('team-1', 'project-1', ''), {
+				wrapper: createWrapper(),
+			})
+
+			expect(tasksServiceMock.getById).not.toHaveBeenCalled()
+			expect(result.current.fetchStatus).toBe('idle')
+		})
+
+		it('не делает запрос, если projectId пустой', () => {
+			const { result } = renderHook(() => useTaskDetail('team-1', '', 'task-1'), {
+				wrapper: createWrapper(),
+			})
+
+			expect(tasksServiceMock.getById).not.toHaveBeenCalled()
+			expect(result.current.fetchStatus).toBe('idle')
+		})
+	})
+
+	describe('useCreateTask', () => {
+		it('после создания обновляет кэш (setQueryData) и инвалидирует список', async () => {
+			const task = createTaskFixture({ id: 'task-new', title: 'New Task' })
+			tasksServiceMock.create.mockResolvedValue(task)
+
+			const invalidateSpy = vi.spyOn(QueryClient.prototype, 'invalidateQueries')
+
+			const { result } = renderHook(() => useCreateTask(), {
+				wrapper: createWrapper(),
+			})
+
+			result.current.mutate({
+				teamId: 'team-1',
+				projectId: 'project-1',
+				data: { title: 'New Task' },
+			})
+
+			await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+			expect(tasksServiceMock.create).toHaveBeenCalledWith('team-1', 'project-1', {
+				title: 'New Task',
+			})
+			expect(
+				queryClient.getQueryData(tasksKeys.detail('team-1', 'project-1', 'task-new')),
+			).toEqual(task)
+			expect(invalidateSpy).toHaveBeenCalledWith({
+				queryKey: tasksKeys.projectLists('team-1', 'project-1'),
+			})
+
+			invalidateSpy.mockRestore()
+		})
+	})
+
+	describe('useUpdateTask', () => {
+		it('обновляет кэш задачи и инвалидирует список', async () => {
+			const task = createTaskFixture({ id: 'task-1', title: 'Updated' })
+			tasksServiceMock.update.mockResolvedValue(task)
+
+			const invalidateSpy = vi.spyOn(QueryClient.prototype, 'invalidateQueries')
+
+			const { result } = renderHook(() => useUpdateTask(), {
+				wrapper: createWrapper(),
+			})
+
+			result.current.mutate({
+				teamId: 'team-1',
+				projectId: 'project-1',
+				taskId: 'task-1',
+				data: { title: 'Updated' },
+			})
+
+			await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+			expect(tasksServiceMock.update).toHaveBeenCalledWith(
+				'team-1',
+				'project-1',
+				'task-1',
+				{ title: 'Updated' },
+			)
+			expect(
+				queryClient.getQueryData(tasksKeys.detail('team-1', 'project-1', 'task-1')),
+			).toEqual(task)
+			expect(invalidateSpy).toHaveBeenCalledWith({
+				queryKey: tasksKeys.projectLists('team-1', 'project-1'),
+			})
+
+			invalidateSpy.mockRestore()
+		})
+	})
+
+	describe('useDeleteTask', () => {
+		it('инвалидирует список и удаляет detail из кэша', async () => {
+			const task = createTaskFixture({ id: 'task-1' })
+
+			queryClient = new QueryClient({
+				defaultOptions: {
+					queries: { retry: false },
+					mutations: { retry: false },
+				},
+			})
+			queryClient.setQueryData(tasksKeys.detail('team-1', 'project-1', 'task-1'), task)
+
+			tasksServiceMock.delete.mockResolvedValue(undefined)
+
+			const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+			const DeleteWrapper = ({ children }: React.PropsWithChildren) => (
+				<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+			)
+			DeleteWrapper.displayName = 'UseDeleteTaskQueryClientWrapper'
+
+			const { result } = renderHook(() => useDeleteTask(), {
+				wrapper: DeleteWrapper,
+			})
+
+			result.current.mutate({
+				teamId: 'team-1',
+				projectId: 'project-1',
+				taskId: 'task-1',
+			})
+
+			await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+			expect(tasksServiceMock.delete).toHaveBeenCalledWith(
+				'team-1',
+				'project-1',
+				'task-1',
+			)
+			expect(invalidateSpy).toHaveBeenCalledWith({
+				queryKey: tasksKeys.projectLists('team-1', 'project-1'),
+			})
+			expect(
+				queryClient.getQueryData(tasksKeys.detail('team-1', 'project-1', 'task-1')),
+			).toBeUndefined()
+
+			invalidateSpy.mockRestore()
+		})
+	})
+})

--- a/apps/web/test/unit/shared/lib/api/tasks-service.spec.ts
+++ b/apps/web/test/unit/shared/lib/api/tasks-service.spec.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest'
+
+import { tasksService } from '@/shared/lib/api/tasks-service'
+
+// tasksService runs in USE_MOCK=true mode: tests cover filtering and CRUD logic.
+// All 5 pre-seeded tasks belong to projectId='mock-project-1'.
+
+const TEAM_ID = 'team-1'
+const PROJECT_ID = 'mock-project-1'
+const UNKNOWN_PROJECT = 'unknown-project'
+
+describe('tasksService (mock mode)', () => {
+	describe('getAll', () => {
+		it('возвращает задачи только для указанного projectId', async () => {
+			const result = await tasksService.getAll(TEAM_ID, PROJECT_ID)
+
+			expect(result.data.length).toBeGreaterThan(0)
+			result.data.forEach((task) => {
+				expect(task.projectId).toBe(PROJECT_ID)
+			})
+		})
+
+		it('возвращает пустой список для неизвестного projectId', async () => {
+			const result = await tasksService.getAll(TEAM_ID, UNKNOWN_PROJECT)
+
+			expect(result.data).toEqual([])
+			expect(result.meta.total).toBe(0)
+		})
+
+		it('фильтрует по статусу — возвращает только задачи с нужным status', async () => {
+			const result = await tasksService.getAll(TEAM_ID, PROJECT_ID, { status: 'TODO' })
+
+			expect(result.data.length).toBeGreaterThan(0)
+			result.data.forEach((task) => {
+				expect(task.status).toBe('TODO')
+			})
+		})
+
+		it('фильтрует по приоритету — возвращает только задачи с нужным priority', async () => {
+			const result = await tasksService.getAll(TEAM_ID, PROJECT_ID, {
+				priority: 'HIGH',
+			})
+
+			expect(result.data.length).toBeGreaterThan(0)
+			result.data.forEach((task) => {
+				expect(task.priority).toBe('HIGH')
+			})
+		})
+
+		it('возвращает пустой список, если фильтр не совпадает ни с одной задачей', async () => {
+			const result = await tasksService.getAll(TEAM_ID, PROJECT_ID, {
+				assigneeId: 'nonexistent-user',
+			})
+
+			expect(result.data).toEqual([])
+		})
+
+		it('meta содержит корректный total', async () => {
+			const result = await tasksService.getAll(TEAM_ID, PROJECT_ID)
+
+			expect(result.meta.total).toBe(result.data.length)
+		})
+	})
+
+	describe('getById', () => {
+		it('возвращает задачу по существующему id', async () => {
+			const task = await tasksService.getById(TEAM_ID, PROJECT_ID, 'mock-task-1')
+
+			expect(task.id).toBe('mock-task-1')
+			expect(task.type).toBe('EPIC')
+		})
+
+		it('отклоняет промис для несуществующего taskId', async () => {
+			await expect(
+				tasksService.getById(TEAM_ID, PROJECT_ID, 'nonexistent'),
+			).rejects.toThrow('Task not found')
+		})
+	})
+
+	describe('create', () => {
+		it('создаёт задачу и возвращает её с присвоенным id', async () => {
+			const task = await tasksService.create(TEAM_ID, PROJECT_ID, {
+				title: 'New Task',
+				type: 'BUG',
+			})
+
+			expect(task.id).toBeDefined()
+			expect(task.title).toBe('New Task')
+			expect(task.type).toBe('BUG')
+			expect(task.projectId).toBe(PROJECT_ID)
+			expect(task.status).toBe('TODO')
+			expect(task.priority).toBe('MEDIUM')
+		})
+
+		it('созданная задача появляется в getAll', async () => {
+			const created = await tasksService.create(TEAM_ID, PROJECT_ID, {
+				title: 'Verifiable Task',
+			})
+
+			const list = await tasksService.getAll(TEAM_ID, PROJECT_ID)
+
+			expect(list.data.some((t) => t.id === created.id)).toBe(true)
+		})
+	})
+
+	describe('update', () => {
+		it('обновляет поля задачи и возвращает обновлённый объект', async () => {
+			const created = await tasksService.create(TEAM_ID, PROJECT_ID, {
+				title: 'Task to update',
+			})
+
+			const updated = await tasksService.update(TEAM_ID, PROJECT_ID, created.id, {
+				title: 'Updated title',
+				status: 'IN_PROGRESS',
+			})
+
+			expect(updated.id).toBe(created.id)
+			expect(updated.title).toBe('Updated title')
+			expect(updated.status).toBe('IN_PROGRESS')
+		})
+
+		it('отклоняет промис для несуществующего taskId', async () => {
+			await expect(
+				tasksService.update(TEAM_ID, PROJECT_ID, 'nonexistent', { title: 'X' }),
+			).rejects.toThrow('Task not found')
+		})
+	})
+
+	describe('delete', () => {
+		it('удаляет задачу из списка', async () => {
+			const created = await tasksService.create(TEAM_ID, PROJECT_ID, {
+				title: 'Task to delete',
+			})
+
+			await tasksService.delete(TEAM_ID, PROJECT_ID, created.id)
+
+			const list = await tasksService.getAll(TEAM_ID, PROJECT_ID)
+
+			expect(list.data.some((t) => t.id === created.id)).toBe(false)
+		})
+
+		it('не бросает ошибку при удалении несуществующего taskId', async () => {
+			await expect(
+				tasksService.delete(TEAM_ID, PROJECT_ID, 'nonexistent'),
+			).resolves.toBeUndefined()
+		})
+	})
+})

--- a/apps/web/test/unit/shared/lib/api/tasks-service.spec.ts
+++ b/apps/web/test/unit/shared/lib/api/tasks-service.spec.ts
@@ -1,148 +1,117 @@
-import { describe, expect, it } from 'vitest'
+import '@/test/mocks/api/http-client.mock'
+
+import { mockApiClient, resetApiClientMock } from '@/test/mocks/api/http-client.mock'
+import { createTaskFixture } from '@/test/mocks/api/tasks.fixtures'
+import { axiosResponse } from '@/test/mocks/api/team-api.fixtures'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import { tasksService } from '@/shared/lib/api/tasks-service'
 
-// tasksService runs in USE_MOCK=true mode: tests cover filtering and CRUD logic.
-// All 5 pre-seeded tasks belong to projectId='mock-project-1'.
+describe('tasksService', () => {
+	beforeEach(() => {
+		resetApiClientMock()
+	})
 
-const TEAM_ID = 'team-1'
-const PROJECT_ID = 'mock-project-1'
-const UNKNOWN_PROJECT = 'unknown-project'
-
-describe('tasksService (mock mode)', () => {
 	describe('getAll', () => {
-		it('возвращает задачи только для указанного projectId', async () => {
-			const result = await tasksService.getAll(TEAM_ID, PROJECT_ID)
+		it('запрашивает список задач с нужным endpoint и params', async () => {
+			const tasks = [
+				createTaskFixture({ id: 'task-1' }),
+				createTaskFixture({ id: 'task-2' }),
+			]
+			const paginatedResponse = {
+				data: tasks,
+				meta: { page: 1, limit: 20, total: 2, totalPages: 1 },
+			}
+			mockApiClient.get.mockResolvedValue(axiosResponse(paginatedResponse))
 
-			expect(result.data.length).toBeGreaterThan(0)
-			result.data.forEach((task) => {
-				expect(task.projectId).toBe(PROJECT_ID)
-			})
+			const result = await tasksService.getAll('team-1', 'project-1')
+
+			expect(mockApiClient.get).toHaveBeenCalledWith(
+				'/teams/team-1/projects/project-1/tasks',
+				{ params: undefined },
+			)
+			expect(result).toEqual(paginatedResponse)
 		})
 
-		it('возвращает пустой список для неизвестного projectId', async () => {
-			const result = await tasksService.getAll(TEAM_ID, UNKNOWN_PROJECT)
+		it('передаёт параметры фильтрации в запрос', async () => {
+			mockApiClient.get.mockResolvedValue(
+				axiosResponse({
+					data: [],
+					meta: { page: 1, limit: 20, total: 0, totalPages: 0 },
+				}),
+			)
 
-			expect(result.data).toEqual([])
-			expect(result.meta.total).toBe(0)
-		})
-
-		it('фильтрует по статусу — возвращает только задачи с нужным status', async () => {
-			const result = await tasksService.getAll(TEAM_ID, PROJECT_ID, { status: 'TODO' })
-
-			expect(result.data.length).toBeGreaterThan(0)
-			result.data.forEach((task) => {
-				expect(task.status).toBe('TODO')
-			})
-		})
-
-		it('фильтрует по приоритету — возвращает только задачи с нужным priority', async () => {
-			const result = await tasksService.getAll(TEAM_ID, PROJECT_ID, {
+			await tasksService.getAll('team-1', 'project-1', {
+				status: 'TODO',
 				priority: 'HIGH',
 			})
 
-			expect(result.data.length).toBeGreaterThan(0)
-			result.data.forEach((task) => {
-				expect(task.priority).toBe('HIGH')
-			})
-		})
-
-		it('возвращает пустой список, если фильтр не совпадает ни с одной задачей', async () => {
-			const result = await tasksService.getAll(TEAM_ID, PROJECT_ID, {
-				assigneeId: 'nonexistent-user',
-			})
-
-			expect(result.data).toEqual([])
-		})
-
-		it('meta содержит корректный total', async () => {
-			const result = await tasksService.getAll(TEAM_ID, PROJECT_ID)
-
-			expect(result.meta.total).toBe(result.data.length)
+			expect(mockApiClient.get).toHaveBeenCalledWith(
+				'/teams/team-1/projects/project-1/tasks',
+				{ params: { status: 'TODO', priority: 'HIGH' } },
+			)
 		})
 	})
 
 	describe('getById', () => {
-		it('возвращает задачу по существующему id', async () => {
-			const task = await tasksService.getById(TEAM_ID, PROJECT_ID, 'mock-task-1')
+		it('запрашивает задачу по правильному endpoint', async () => {
+			const task = createTaskFixture({ id: 'task-1' })
+			mockApiClient.get.mockResolvedValue(axiosResponse(task))
 
-			expect(task.id).toBe('mock-task-1')
-			expect(task.type).toBe('EPIC')
-		})
+			const result = await tasksService.getById('team-1', 'project-1', 'task-1')
 
-		it('отклоняет промис для несуществующего taskId', async () => {
-			await expect(
-				tasksService.getById(TEAM_ID, PROJECT_ID, 'nonexistent'),
-			).rejects.toThrow('Task not found')
+			expect(mockApiClient.get).toHaveBeenCalledWith(
+				'/teams/team-1/projects/project-1/tasks/task-1',
+			)
+			expect(result).toEqual(task)
 		})
 	})
 
 	describe('create', () => {
-		it('создаёт задачу и возвращает её с присвоенным id', async () => {
-			const task = await tasksService.create(TEAM_ID, PROJECT_ID, {
+		it('отправляет POST с данными и возвращает созданную задачу', async () => {
+			const task = createTaskFixture({ id: 'task-new', title: 'New Task', type: 'BUG' })
+			mockApiClient.post.mockResolvedValue(axiosResponse(task))
+
+			const result = await tasksService.create('team-1', 'project-1', {
 				title: 'New Task',
 				type: 'BUG',
 			})
 
-			expect(task.id).toBeDefined()
-			expect(task.title).toBe('New Task')
-			expect(task.type).toBe('BUG')
-			expect(task.projectId).toBe(PROJECT_ID)
-			expect(task.status).toBe('TODO')
-			expect(task.priority).toBe('MEDIUM')
-		})
-
-		it('созданная задача появляется в getAll', async () => {
-			const created = await tasksService.create(TEAM_ID, PROJECT_ID, {
-				title: 'Verifiable Task',
-			})
-
-			const list = await tasksService.getAll(TEAM_ID, PROJECT_ID)
-
-			expect(list.data.some((t) => t.id === created.id)).toBe(true)
+			expect(mockApiClient.post).toHaveBeenCalledWith(
+				'/teams/team-1/projects/project-1/tasks',
+				{ title: 'New Task', type: 'BUG' },
+			)
+			expect(result).toEqual(task)
 		})
 	})
 
 	describe('update', () => {
-		it('обновляет поля задачи и возвращает обновлённый объект', async () => {
-			const created = await tasksService.create(TEAM_ID, PROJECT_ID, {
-				title: 'Task to update',
+		it('отправляет PATCH с данными и возвращает обновлённую задачу', async () => {
+			const task = createTaskFixture({ id: 'task-1', title: 'Updated', status: 'DONE' })
+			mockApiClient.patch.mockResolvedValue(axiosResponse(task))
+
+			const result = await tasksService.update('team-1', 'project-1', 'task-1', {
+				title: 'Updated',
+				status: 'DONE',
 			})
 
-			const updated = await tasksService.update(TEAM_ID, PROJECT_ID, created.id, {
-				title: 'Updated title',
-				status: 'IN_PROGRESS',
-			})
-
-			expect(updated.id).toBe(created.id)
-			expect(updated.title).toBe('Updated title')
-			expect(updated.status).toBe('IN_PROGRESS')
-		})
-
-		it('отклоняет промис для несуществующего taskId', async () => {
-			await expect(
-				tasksService.update(TEAM_ID, PROJECT_ID, 'nonexistent', { title: 'X' }),
-			).rejects.toThrow('Task not found')
+			expect(mockApiClient.patch).toHaveBeenCalledWith(
+				'/teams/team-1/projects/project-1/tasks/task-1',
+				{ title: 'Updated', status: 'DONE' },
+			)
+			expect(result).toEqual(task)
 		})
 	})
 
 	describe('delete', () => {
-		it('удаляет задачу из списка', async () => {
-			const created = await tasksService.create(TEAM_ID, PROJECT_ID, {
-				title: 'Task to delete',
-			})
+		it('отправляет DELETE на правильный endpoint', async () => {
+			mockApiClient.delete.mockResolvedValue(axiosResponse(undefined))
 
-			await tasksService.delete(TEAM_ID, PROJECT_ID, created.id)
+			await tasksService.delete('team-1', 'project-1', 'task-1')
 
-			const list = await tasksService.getAll(TEAM_ID, PROJECT_ID)
-
-			expect(list.data.some((t) => t.id === created.id)).toBe(false)
-		})
-
-		it('не бросает ошибку при удалении несуществующего taskId', async () => {
-			await expect(
-				tasksService.delete(TEAM_ID, PROJECT_ID, 'nonexistent'),
-			).resolves.toBeUndefined()
+			expect(mockApiClient.delete).toHaveBeenCalledWith(
+				'/teams/team-1/projects/project-1/tasks/task-1',
+			)
 		})
 	})
 })

--- a/packages/types/src/tasks/schemas/create-task.schema.ts
+++ b/packages/types/src/tasks/schemas/create-task.schema.ts
@@ -10,6 +10,8 @@ export const TaskStatusSchema = z.enum([
 
 export const PrioritySchema = z.enum(['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'])
 
+export const TaskTypeSchema = z.enum(['EPIC', 'STORY', 'BUG', 'TECH_DEBT', 'TASK'])
+
 export const createTaskSchema = z.object({
 	title: z
 		.string({ message: 'Название должно быть строкой' })
@@ -26,6 +28,7 @@ export const createTaskSchema = z.object({
 		.string({ message: 'Дата дедлайна должна быть строкой' })
 		.datetime({ message: 'Дата дедлайна должна быть в формате ISO 8601' })
 		.optional(),
+	type: TaskTypeSchema.optional(),
 })
 
 export type CreateTask = z.infer<typeof createTaskSchema>

--- a/packages/types/src/tasks/types/task.types.ts
+++ b/packages/types/src/tasks/types/task.types.ts
@@ -1,8 +1,14 @@
 import { z } from 'zod'
-import { TaskStatusSchema, PrioritySchema } from '../schemas/create-task.schema'
+import {
+	TaskStatusSchema,
+	PrioritySchema,
+	TaskTypeSchema,
+} from '../schemas/create-task.schema'
+import type { PaginationParams } from '../../pagination'
 
 export type TaskStatus = z.infer<typeof TaskStatusSchema>
 export type Priority = z.infer<typeof PrioritySchema>
+export type TaskType = z.infer<typeof TaskTypeSchema>
 
 export interface Task {
 	id: string
@@ -10,10 +16,17 @@ export interface Task {
 	description: string | null
 	status: TaskStatus
 	priority: Priority
+	type?: TaskType
 	position: number
 	dueDate: string | null
 	projectId: string
 	assigneeId: string | null
 	createdAt: string
 	updatedAt: string
+}
+
+export interface TaskFilterParams extends PaginationParams {
+	status?: TaskStatus
+	priority?: Priority
+	assigneeId?: string
 }


### PR DESCRIPTION
что реализовано :
- Добавлены типы TaskType (EPIC, STORY, BUG, TECH_DEBT, TASK) и
  TaskFilterParams в @repo/types
  - Создан tasks-service.ts с полным CRUD через axios (getAll, getById,
  create, update, delete)
  - Созданы React Query хуки: useTasksList, useTaskDetail, useCreateTask,
  useUpdateTask, useDeleteTask
  - Написаны unit-тесты для сервиса, ключей кэша и хуков
