### PR TITLE
feat(api): реализовать получение доски проекта с группировкой по статусам

### DIFF
--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -69,6 +69,18 @@ export class TasksController {
 		)
 	}
 
+	@ApiOperation({ summary: 'Получить доску (задачи, сгруппированные по статусам)' })
+	@ApiOkResponse({ description: 'Массив колонок доски' })
+	@ApiForbiddenResponse({ description: 'Вы не являетесь участником этой команды' })
+	@Get('board')
+	getBoard(
+		@Param('teamId') teamId: string,
+		@Param('projectId') projectId: string,
+		@Authorized('id') userId: string,
+	) {
+		return this.tasksService.getBoard(teamId, projectId, userId)
+	}
+
 	@ApiOperation({ summary: 'Получить задачу по ID' })
 	@ApiOkResponse({ description: 'Данные задачи' })
 	@ApiNotFoundResponse({ description: 'Задача не найдена' })

--- a/apps/api/src/tasks/tasks.service.ts
+++ b/apps/api/src/tasks/tasks.service.ts
@@ -1,5 +1,5 @@
 import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common'
-import { TaskStatus, TeamRole, type TeamMember } from 'generated/prisma/client'
+import { type Task, TaskStatus, TeamRole, type TeamMember } from 'generated/prisma/client'
 import { PrismaService } from '../../prisma/prisma.service'
 import {
 	buildPaginatedResponse,
@@ -145,6 +145,30 @@ export class TasksService {
 				...(dto.dueDate !== undefined && { dueDate: new Date(dto.dueDate) }),
 			},
 		})
+	}
+
+	async getBoard(
+		teamId: string,
+		projectId: string,
+		userId: string,
+	): Promise<Array<{ status: TaskStatus; tasks: Task[] }>> {
+		await this.assertTeamMember(teamId, userId)
+		await this.findProjectOrThrow(teamId, projectId)
+
+		const tasks = await this.prisma.task.findMany({
+			where: { projectId },
+			orderBy: { position: 'asc' },
+		})
+
+		const grouped = new Map<TaskStatus, Task[]>(
+			Object.values(TaskStatus).map((s) => [s, []]),
+		)
+
+		for (const task of tasks) {
+			grouped.get(task.status as TaskStatus)!.push(task)
+		}
+
+		return Array.from(grouped, ([status, tasks]) => ({ status, tasks }))
 	}
 
 	async remove(teamId: string, projectId: string, taskId: string, userId: string) {

--- a/apps/api/test/helpers/tasks.helpers.ts
+++ b/apps/api/test/helpers/tasks.helpers.ts
@@ -102,3 +102,8 @@ export const CREATE_TASK_DTO = {
 export const UPDATE_TASK_DTO = {
 	title: 'Updated title',
 }
+
+export const makeTask = (overrides: Partial<typeof MOCK_TASK>) => ({
+	...MOCK_TASK,
+	...overrides,
+})

--- a/apps/api/test/unit/tasks/tasks.service.spec.ts
+++ b/apps/api/test/unit/tasks/tasks.service.spec.ts
@@ -411,9 +411,9 @@ describe('TasksService', () => {
 
 	// ── getBoard ─────────────────────────────────────────────────────────────────
 	describe('getBoard', () => {
-		const ALL_STATUSES = ['BACKLOG', 'TODO', 'IN_PROGRESS', 'IN_REVIEW', 'DONE'] as const
+		const ALL_STATUSES = ['TODO', 'IN_PROGRESS', 'IN_REVIEW', 'DONE'] as const
 
-		it('должен вернуть все 5 колонок даже если задач нет', async () => {
+		it('должен вернуть все 4 колонки даже если задач нет', async () => {
 			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
 			prisma.project.findUnique.mockResolvedValue(MOCK_PROJECT)
 			prisma.task.findMany.mockResolvedValue([])
@@ -432,11 +432,6 @@ describe('TasksService', () => {
 			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
 			prisma.project.findUnique.mockResolvedValue(MOCK_PROJECT)
 
-			const backlogTask = makeTask({
-				id: 'task-b',
-				status: 'BACKLOG' as never,
-				position: 1,
-			})
 			const todoTask1 = makeTask({ id: 'task-t1', status: 'TODO' as never, position: 1 })
 			const todoTask2 = makeTask({ id: 'task-t2', status: 'TODO' as never, position: 2 })
 			const inProgressTask = makeTask({
@@ -447,7 +442,6 @@ describe('TasksService', () => {
 			const doneTask = makeTask({ id: 'task-d', status: 'DONE' as never, position: 1 })
 
 			prisma.task.findMany.mockResolvedValue([
-				backlogTask,
 				todoTask1,
 				todoTask2,
 				inProgressTask,
@@ -458,7 +452,6 @@ describe('TasksService', () => {
 
 			const find = (s: string) => result.find((c) => c.status === s)!
 
-			expect(find('BACKLOG').tasks).toEqual([backlogTask])
 			expect(find('TODO').tasks).toEqual([todoTask1, todoTask2])
 			expect(find('IN_PROGRESS').tasks).toEqual([inProgressTask])
 			expect(find('IN_REVIEW').tasks).toEqual([])

--- a/apps/api/test/unit/tasks/tasks.service.spec.ts
+++ b/apps/api/test/unit/tasks/tasks.service.spec.ts
@@ -5,6 +5,7 @@ import { TasksService } from '../../../src/tasks/tasks.service'
 import {
 	createPrismaMock,
 	CREATE_TASK_DTO,
+	makeTask,
 	MEMBER_ADMIN,
 	MEMBER_OWNER,
 	MEMBER_PLAIN,
@@ -405,6 +406,115 @@ describe('TasksService', () => {
 			).rejects.toThrow(NotFoundException)
 
 			expect(prisma.task.update).not.toHaveBeenCalled()
+		})
+	})
+
+	// ── getBoard ─────────────────────────────────────────────────────────────────
+	describe('getBoard', () => {
+		const ALL_STATUSES = ['BACKLOG', 'TODO', 'IN_PROGRESS', 'IN_REVIEW', 'DONE'] as const
+
+		it('должен вернуть все 5 колонок даже если задач нет', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.project.findUnique.mockResolvedValue(MOCK_PROJECT)
+			prisma.task.findMany.mockResolvedValue([])
+
+			const result = await service.getBoard(TEAM_ID, PROJECT_ID, USER_ID)
+
+			expect(result).toHaveLength(ALL_STATUSES.length)
+			const statuses = result.map((col) => col.status)
+			for (const s of ALL_STATUSES) {
+				expect(statuses).toContain(s)
+			}
+			result.forEach((col) => expect(col.tasks).toEqual([]))
+		})
+
+		it('должен правильно распределить задачи по колонкам', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.project.findUnique.mockResolvedValue(MOCK_PROJECT)
+
+			const backlogTask = makeTask({
+				id: 'task-b',
+				status: 'BACKLOG' as never,
+				position: 1,
+			})
+			const todoTask1 = makeTask({ id: 'task-t1', status: 'TODO' as never, position: 1 })
+			const todoTask2 = makeTask({ id: 'task-t2', status: 'TODO' as never, position: 2 })
+			const inProgressTask = makeTask({
+				id: 'task-ip',
+				status: 'IN_PROGRESS' as never,
+				position: 1,
+			})
+			const doneTask = makeTask({ id: 'task-d', status: 'DONE' as never, position: 1 })
+
+			prisma.task.findMany.mockResolvedValue([
+				backlogTask,
+				todoTask1,
+				todoTask2,
+				inProgressTask,
+				doneTask,
+			])
+
+			const result = await service.getBoard(TEAM_ID, PROJECT_ID, USER_ID)
+
+			const find = (s: string) => result.find((c) => c.status === s)!
+
+			expect(find('BACKLOG').tasks).toEqual([backlogTask])
+			expect(find('TODO').tasks).toEqual([todoTask1, todoTask2])
+			expect(find('IN_PROGRESS').tasks).toEqual([inProgressTask])
+			expect(find('IN_REVIEW').tasks).toEqual([])
+			expect(find('DONE').tasks).toEqual([doneTask])
+		})
+
+		it('должен запрашивать задачи с сортировкой по position ASC', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.project.findUnique.mockResolvedValue(MOCK_PROJECT)
+			prisma.task.findMany.mockResolvedValue([])
+
+			await service.getBoard(TEAM_ID, PROJECT_ID, USER_ID)
+
+			expect(prisma.task.findMany).toHaveBeenCalledWith(
+				expect.objectContaining({
+					where: { projectId: PROJECT_ID },
+					orderBy: { position: 'asc' },
+				}),
+			)
+		})
+
+		it('должен сохранять порядок задач по position внутри колонки', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.project.findUnique.mockResolvedValue(MOCK_PROJECT)
+
+			const t1 = makeTask({ id: 'task-1', status: 'TODO' as never, position: 1 })
+			const t2 = makeTask({ id: 'task-2', status: 'TODO' as never, position: 2 })
+			const t3 = makeTask({ id: 'task-3', status: 'TODO' as never, position: 3 })
+
+			prisma.task.findMany.mockResolvedValue([t1, t2, t3])
+
+			const result = await service.getBoard(TEAM_ID, PROJECT_ID, USER_ID)
+
+			const todoCol = result.find((c) => c.status === 'TODO')!
+			expect(todoCol.tasks).toEqual([t1, t2, t3])
+		})
+
+		it('должен выбросить ForbiddenException если пользователь не является членом команды', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(null)
+
+			await expect(service.getBoard(TEAM_ID, PROJECT_ID, USER_ID)).rejects.toThrow(
+				ForbiddenException,
+			)
+
+			expect(prisma.task.findMany).not.toHaveBeenCalled()
+		})
+
+		it('должен выбросить NotFoundException если проект не найден', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.project.findUnique.mockResolvedValue(null)
+
+			await expect(service.getBoard(TEAM_ID, PROJECT_ID, USER_ID)).rejects.toThrow(
+				NotFoundException,
+			)
+
+			expect(prisma.task.findMany).not.toHaveBeenCalled()
 		})
 	})
 

--- a/packages/types/src/tasks/types/task.types.ts
+++ b/packages/types/src/tasks/types/task.types.ts
@@ -30,3 +30,8 @@ export interface TaskFilterParams extends PaginationParams {
 	priority?: Priority
 	assigneeId?: string
 }
+
+export interface BoardColumn {
+	status: TaskStatus
+	tasks: Task[]
+}


### PR DESCRIPTION
## Что сделано:
- Создан и экспортирован тип `BoardColumn`.
- Реализована функция `getBoard` с проверкой прав доступа пользователя к проекту.
- Добавлена сортировка задач внутри колонок по полю `position` (ASC).
- Обеспечен возврат всех 4 базовых статусов из `TaskStatus`, включая пустые колонки.
- Написаны unit-тесты для проверки группировки, сортировки и обработки пустых колонок.
