### PR TITLE
feat(api): реализовать логику и эндпоинт для перемещения задач на доске

### DIFF
--- a/apps/api/src/tasks/dto/move-task.dto.ts
+++ b/apps/api/src/tasks/dto/move-task.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger'
+import { type TaskStatus, moveTaskSchema } from '@repo/types'
+import { createZodDto } from 'nestjs-zod'
+
+export class MoveTaskDto extends createZodDto(moveTaskSchema) {
+	@ApiProperty({
+		example: 'IN_PROGRESS',
+		enum: ['TODO', 'BACKLOG', 'IN_PROGRESS', 'IN_REVIEW', 'DONE'],
+		description: 'Новый статус задачи',
+	})
+	status: TaskStatus
+
+	@ApiProperty({
+		example: 2,
+		description: 'Новая позиция задачи внутри колонки (начиная с 0)',
+	})
+	position: number
+}

--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -25,6 +25,7 @@ import { Authorization } from '../auth/decorators/authorization.decorator'
 import { Authorized } from '../auth/decorators/authorized.decorator'
 import { BoardResponseDto } from './dto/board-response.dto'
 import { CreateTaskDto } from './dto/create-task.dto'
+import { MoveTaskDto } from './dto/move-task.dto'
 import { TaskResponseDto } from './dto/task-response.dto'
 import { UpdateTaskDto } from './dto/update-task.dto'
 import { TaskFilterQueryDto } from './dto/task-filter-query.dto'
@@ -110,6 +111,21 @@ export class TasksController {
 		@Body() dto: UpdateTaskDto,
 	) {
 		return this.tasksService.update(teamId, projectId, taskId, userId, dto)
+	}
+
+	@ApiOperation({ summary: 'Переместить задачу (сменить статус / позицию)' })
+	@ApiOkResponse({ type: TaskResponseDto, description: 'Задача перемещена' })
+	@ApiNotFoundResponse({ description: 'Задача не найдена' })
+	@ApiForbiddenResponse({ description: 'Вы не являетесь участником этой команды' })
+	@Patch(':taskId/move')
+	moveTask(
+		@Param('teamId') teamId: string,
+		@Param('projectId') projectId: string,
+		@Param('taskId') taskId: string,
+		@Authorized('id') userId: string,
+		@Body() dto: MoveTaskDto,
+	) {
+		return this.tasksService.moveTask(teamId, projectId, taskId, userId, dto)
 	}
 
 	@ApiOperation({ summary: 'Удалить задачу (OWNER / ADMIN)' })

--- a/apps/api/src/tasks/tasks.service.ts
+++ b/apps/api/src/tasks/tasks.service.ts
@@ -7,6 +7,7 @@ import {
 	type PaginationOptions,
 } from '../utils/pagination.util'
 import { CreateTaskDto } from './dto/create-task.dto'
+import { MoveTaskDto } from './dto/move-task.dto'
 import { UpdateTaskDto } from './dto/update-task.dto'
 import { TaskFilterQueryDto } from './dto/task-filter-query.dto'
 
@@ -169,6 +170,26 @@ export class TasksService {
 		}
 
 		return Array.from(grouped, ([status, tasks]) => ({ status, tasks }))
+	}
+
+	async moveTask(
+		teamId: string,
+		projectId: string,
+		taskId: string,
+		userId: string,
+		dto: MoveTaskDto,
+	) {
+		await this.assertTeamMember(teamId, userId)
+		await this.findProjectOrThrow(teamId, projectId)
+		await this.findTaskOrThrow(projectId, taskId)
+
+		return this.prisma.task.update({
+			where: { id: taskId },
+			data: {
+				status: dto.status as never,
+				position: dto.position,
+			},
+		})
 	}
 
 	async remove(teamId: string, projectId: string, taskId: string, userId: string) {

--- a/apps/api/test/helpers/tasks.helpers.ts
+++ b/apps/api/test/helpers/tasks.helpers.ts
@@ -103,6 +103,11 @@ export const UPDATE_TASK_DTO = {
 	title: 'Updated title',
 }
 
+export const MOVE_TASK_DTO = {
+	status: 'IN_PROGRESS' as const,
+	position: 1,
+}
+
 export const makeTask = (overrides: Partial<typeof MOCK_TASK>) => ({
 	...MOCK_TASK,
 	...overrides,

--- a/apps/api/test/unit/tasks/tasks.service.spec.ts
+++ b/apps/api/test/unit/tasks/tasks.service.spec.ts
@@ -11,6 +11,7 @@ import {
 	MEMBER_PLAIN,
 	MOCK_PROJECT,
 	MOCK_TASK,
+	MOVE_TASK_DTO,
 	OTHER_USER_ID,
 	PROJECT_ID,
 	TEAM_ID,
@@ -508,6 +509,66 @@ describe('TasksService', () => {
 			)
 
 			expect(prisma.task.findMany).not.toHaveBeenCalled()
+		})
+	})
+
+	// ── moveTask ─────────────────────────────────────────────────────────────────
+	describe('moveTask', () => {
+		it('должен сменить статус задачи', async () => {
+			const movedTask = { ...MOCK_TASK, status: 'IN_PROGRESS' as const, position: 1 }
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.project.findUnique.mockResolvedValue(MOCK_PROJECT)
+			prisma.task.findUnique.mockResolvedValue(MOCK_TASK)
+			prisma.task.update.mockResolvedValue(movedTask)
+
+			const result = await service.moveTask(TEAM_ID, PROJECT_ID, MOCK_TASK.id, USER_ID, {
+				...MOVE_TASK_DTO,
+				status: 'IN_PROGRESS',
+			} as never)
+
+			expect(prisma.task.update).toHaveBeenCalledWith(
+				expect.objectContaining({
+					where: { id: MOCK_TASK.id },
+					data: expect.objectContaining({ status: 'IN_PROGRESS' }),
+				}),
+			)
+			expect(result.status).toBe('IN_PROGRESS')
+		})
+
+		it('должен обновить позицию задачи внутри той же колонки', async () => {
+			const movedTask = { ...MOCK_TASK, position: 3 }
+			prisma.teamMember.findUnique.mockResolvedValue(MEMBER_OWNER)
+			prisma.project.findUnique.mockResolvedValue(MOCK_PROJECT)
+			prisma.task.findUnique.mockResolvedValue(MOCK_TASK)
+			prisma.task.update.mockResolvedValue(movedTask)
+
+			const result = await service.moveTask(TEAM_ID, PROJECT_ID, MOCK_TASK.id, USER_ID, {
+				status: 'TODO',
+				position: 3,
+			} as never)
+
+			expect(prisma.task.update).toHaveBeenCalledWith(
+				expect.objectContaining({
+					data: expect.objectContaining({ position: 3 }),
+				}),
+			)
+			expect(result.position).toBe(3)
+		})
+
+		it('должен выбросить ForbiddenException если пользователь не является членом команды', async () => {
+			prisma.teamMember.findUnique.mockResolvedValue(null)
+
+			await expect(
+				service.moveTask(
+					TEAM_ID,
+					PROJECT_ID,
+					MOCK_TASK.id,
+					USER_ID,
+					MOVE_TASK_DTO as never,
+				),
+			).rejects.toThrow(ForbiddenException)
+
+			expect(prisma.task.update).not.toHaveBeenCalled()
 		})
 	})
 

--- a/packages/types/src/tasks/index.ts
+++ b/packages/types/src/tasks/index.ts
@@ -1,4 +1,5 @@
 export * from './types/task.types'
 export * from './schemas/create-task.schema'
 export * from './schemas/update-task.schema'
+export * from './schemas/move-task.schema'
 export * from './schemas/task-filter-query.schema'

--- a/packages/types/src/tasks/schemas/move-task.schema.ts
+++ b/packages/types/src/tasks/schemas/move-task.schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod'
+import { TaskStatusSchema } from './create-task.schema'
+
+export const moveTaskSchema = z.object({
+	status: TaskStatusSchema,
+	position: z.number().int().min(0),
+})
+
+export type MoveTask = z.infer<typeof moveTaskSchema>


### PR DESCRIPTION
## Что сделано:
- Создан класс `MoveTaskDto` с валидацией входных данных для статуса и позиции.
- Внедрен метод `moveTask` в сервис задач с проверкой прав доступа участника команды.
- Обновление полей `status` и `position` выполняется атомарно через Prisma.
- Добавлен эндпоинт `PATCH teams/:teamId/projects/:projectId/tasks/:taskId/move` в `TasksController`.
- Написаны unit-тесты, покрывающие успешные с