### PR TITLE
feat(docs): добавить шорткаты для запуска Storybook и настроить документацию

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,9 @@
 		"test": "vitest run --config ./vitest.config.ts",
 		"pretest:e2e": "pnpm --filter @repo/vitest-config build",
 		"test:e2e": "vitest run --config ./vitest.config.e2e.ts",
-		"test:watch": "vitest"
+		"test:watch": "vitest",
+		"storybook": "pnpm --filter @repo/ui storybook",
+		"storybook:build": "pnpm --filter @repo/ui build-storybook"
 	},
 	"dependencies": {
 		"@dnd-kit/core": "^6.3.1",

--- a/docs/frontend/storybook.md
+++ b/docs/frontend/storybook.md
@@ -1,0 +1,78 @@
+# Storybook
+
+## Зачем
+
+Storybook позволяет разрабатывать и тестировать UI-компоненты изолированно, не запуская всё приложение. Каждая _story_ — это отдельное состояние компонента с фиксированными пропсами.
+
+## Запуск
+
+Из корня монорепозитория:
+
+```bash
+pnpm storybook
+```
+
+Из директории `apps/web`:
+
+```bash
+pnpm storybook
+```
+
+Обе команды запускают Storybook на `http://localhost:6006`.
+
+## Сборка статической версии
+
+```bash
+pnpm storybook:build
+```
+
+Собранные файлы окажутся в `packages/ui/storybook-static/`.
+
+## Архитектура
+
+Конфиг и все `.stories` файлы живут в `packages/ui` — там же, где хранятся сами компоненты. Это сделано намеренно: `@repo/ui` — общий UI-пакет для всех приложений монорепозитория, и логично держать компоненты рядом с их документацией.
+
+```
+packages/ui/
+├── .storybook/          # конфиг Storybook (main.ts, preview.ts)
+└── src/
+    └── components/
+        ├── button.tsx
+        └── button.stories.tsx   # story лежит рядом с компонентом
+```
+
+## Добавление новой story
+
+Создай файл `<ComponentName>.stories.tsx` рядом с компонентом. Пример для `Button`:
+
+```tsx
+// packages/ui/src/components/button.stories.tsx
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { Button } from './button'
+
+const meta = {
+	title: 'UI/Button',
+	component: Button,
+	tags: ['autodocs'],
+} satisfies Meta<typeof Button>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Primary: Story = {
+	args: {
+		children: 'Нажми меня',
+		variant: 'default',
+	},
+}
+
+export const Destructive: Story = {
+	args: {
+		children: 'Удалить',
+		variant: 'destructive',
+	},
+}
+```
+
+Storybook подхватит файл автоматически при следующем запуске.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
 		"prisma:migrate": "pnpm --filter api prisma:migrate",
 		"prisma:studio": "pnpm --filter api prisma:studio",
 		"prisma:seed": "pnpm --filter api prisma:seed",
-		"prisma:reset": "pnpm --filter api prisma:migrate reset --force"
+		"prisma:reset": "pnpm --filter api prisma:migrate reset --force",
+		"storybook": "pnpm --filter @repo/ui storybook",
+		"storybook:build": "pnpm --filter @repo/ui build-storybook"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "^20.4.1",


### PR DESCRIPTION
## Что сделано:
- Добавлены прокси-скрипты запуска и сборки Storybook в корневой `package.json`.
- Добавлены шорткаты для запуска Storybook непосредственно из директории `apps/web`.
- Создан подробный гайд `docs/frontend/storybook.md` с архитектурным описанием, командами запуска, URL-адресами и примером написания новых сторибук-историй.
